### PR TITLE
Adds a new Kibana Connector

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,10 @@ Thumbs.db
 # Ruby / Jekyll
 **/Gemfile
 **/Gemfile.lock
+# tmp cache
+tmp_cache/
+# MITRE ATT&CK data is fetched during deployment by sync_mitre_attack_dicts.
+backend/detections/mitre_attack_stub.json
+
+# TypeScript incremental build cache
+frontend/tsconfig.tsbuildinfo

--- a/backend/detections/kibana_service.py
+++ b/backend/detections/kibana_service.py
@@ -14,11 +14,15 @@ from .services import append_rule_version, summarize_payload_changes, user_name_
 
 
 def kibana_integration() -> Integration | None:
-    qs = Integration.objects.filter(type="elasticsearch").order_by("-updated_at", "-created_at")
-    for item in qs:
-        cfg = item.config or {}
-        if cfg.get("host"):
-            return item
+    qs = Integration.objects.filter(type__in=["kibana", "elasticsearch"]).order_by("-updated_at", "-created_at")
+    items = list(qs)
+    for preferred_type in ("kibana", "elasticsearch"):
+        for item in items:
+            if item.type != preferred_type:
+                continue
+            cfg = item.config or {}
+            if cfg.get("host"):
+                return item
     return None
 
 

--- a/backend/integrations/serializers.py
+++ b/backend/integrations/serializers.py
@@ -34,6 +34,6 @@ class IntegrationSerializer(serializers.ModelSerializer):
 
     def validate(self, data):
         t = data.get('type') or (self.instance.type if self.instance else None)
-        if t and t != 'elasticsearch':
-            raise serializers.ValidationError('only elasticsearch integrations are supported')
+        if t and t not in {'elasticsearch', 'kibana'}:
+            raise serializers.ValidationError('only elasticsearch and kibana integrations are supported')
         return data

--- a/frontend/src/modules/integrations/Integrations.tsx
+++ b/frontend/src/modules/integrations/Integrations.tsx
@@ -27,6 +27,7 @@ const { Title, Text } = Typography;
 
 type AuthType = 'none' | 'basic' | 'api_key';
 type ProtocolType = 'https' | 'http';
+type ConnectorKind = 'elasticsearch' | 'kibana';
 
 type ElasticFormData = {
   name: string;
@@ -41,17 +42,31 @@ type ElasticFormData = {
   path: string;
 };
 
-const DEFAULT_FORM: ElasticFormData = {
-  name: 'Elastic Stack (ELK)',
-  protocol: 'https',
-  host: '',
-  port: 9200,
-  authType: 'none',
-  username: '',
-  password: '',
-  apiKey: '',
-  index: 'alerts',
-  path: '/_cluster/health',
+const CONNECTOR_DEFAULTS: Record<ConnectorKind, ElasticFormData> = {
+  elasticsearch: {
+    name: 'Elastic Stack (ELK)',
+    protocol: 'https',
+    host: '',
+    port: 9200,
+    authType: 'none',
+    username: '',
+    password: '',
+    apiKey: '',
+    index: 'alerts',
+    path: '/_cluster/health',
+  },
+  kibana: {
+    name: 'Kibana',
+    protocol: 'https',
+    host: '',
+    port: 5601,
+    authType: 'none',
+    username: '',
+    password: '',
+    apiKey: '',
+    index: '',
+    path: '/api/status',
+  },
 };
 
 const HOST_PATTERN = /^(localhost|(([a-zA-Z0-9-]+\.)*[a-zA-Z0-9-]+)|(\d{1,3}(\.\d{1,3}){3}))$/;
@@ -60,8 +75,9 @@ const Integrations: React.FC = () => {
   const [items, setItems] = useState<any[]>([]);
   const [isReadonly, setIsReadonly] = useState(false);
   const [modalOpen, setModalOpen] = useState(false);
+  const [connectorKind, setConnectorKind] = useState<ConnectorKind>('elasticsearch');
   const [editingItem, setEditingItem] = useState<any | null>(null);
-  const [formData, setFormData] = useState<ElasticFormData>(DEFAULT_FORM);
+  const [formData, setFormData] = useState<ElasticFormData>(CONNECTOR_DEFAULTS.elasticsearch);
   const [testing, setTesting] = useState(false);
   const [saving, setSaving] = useState(false);
   const [hostTouched, setHostTouched] = useState(false);
@@ -84,6 +100,10 @@ const Integrations: React.FC = () => {
 
   const elkItems = useMemo(
     () => (Array.isArray(items) ? items.filter((item: any) => item?.type === 'elasticsearch') : []),
+    [items]
+  );
+  const kibanaItems = useMemo(
+    () => (Array.isArray(items) ? items.filter((item: any) => item?.type === 'kibana') : []),
     [items]
   );
 
@@ -110,59 +130,63 @@ const Integrations: React.FC = () => {
   };
 
   // Parse persisted integration config into UI-friendly fields.
-  const normalizeFromItem = (item: any): ElasticFormData => {
+  const normalizeFromItem = (item: any, kind: ConnectorKind): ElasticFormData => {
+    const defaults = CONNECTOR_DEFAULTS[kind];
     const cfg = item?.config || {};
     const hostRaw = String(cfg.host || item?.host || '').trim();
-    let protocol: ProtocolType = 'https';
+    let protocol: ProtocolType = defaults.protocol;
     let host = '';
-    let port = 9200;
+    let port = defaults.port;
     try {
       const parsed = new URL(hostRaw);
       protocol = parsed.protocol === 'http:' ? 'http' : 'https';
       host = parsed.hostname;
-      port = parsed.port ? Number(parsed.port) : 9200;
+      port = parsed.port ? Number(parsed.port) : defaults.port;
     } catch {
       host = hostRaw.replace(/^https?:\/\//, '').split(':')[0] || '';
       const maybePort = Number(hostRaw.split(':').pop());
-      port = Number.isFinite(maybePort) && maybePort > 0 ? maybePort : 9200;
+      port = Number.isFinite(maybePort) && maybePort > 0 ? maybePort : defaults.port;
     }
 
     const authType: AuthType = cfg.auth_type === 'basic' || cfg.auth_type === 'api_key' ? cfg.auth_type : 'none';
 
     return {
-      name: item?.name || 'Elastic Stack (ELK)',
+      name: item?.name || defaults.name,
       protocol,
       host,
-      port: port >= 1 && port <= 65535 ? port : 9200,
+      port: port >= 1 && port <= 65535 ? port : defaults.port,
       authType,
       username: String(cfg.username || ''),
       password: String(cfg.password || ''),
       apiKey: String(cfg.api_key || ''),
-      index: String(cfg.index || 'alerts'),
-      path: String(cfg.path || '/_cluster/health'),
+      index: String(cfg.index || defaults.index),
+      path: String(cfg.path || defaults.path),
     };
   };
 
   const resetModalState = () => {
     setEditingItem(null);
-    setFormData(DEFAULT_FORM);
+    setConnectorKind('elasticsearch');
+    setFormData(CONNECTOR_DEFAULTS.elasticsearch);
     setHostTouched(false);
     setTesting(false);
     setSaving(false);
   };
 
-  // Clicking ELK card (or edit) opens modal with existing values if available.
-  const openFromCard = (item?: any) => {
+  // Clicking a connector card opens modal with existing values if available.
+  const openFromCard = (kind: ConnectorKind, item?: any) => {
+    const defaults = CONNECTOR_DEFAULTS[kind];
+    setConnectorKind(kind);
     setHostTouched(false);
     if (item) {
       setEditingItem(item);
-      const normalized = normalizeFromItem(item);
+      const normalized = normalizeFromItem(item, kind);
       setFormData(normalized);
       setIndicesList(normalized.index ? [normalized.index] : []);
     } else {
       setEditingItem(null);
-      setFormData(DEFAULT_FORM);
-      setIndicesList([DEFAULT_FORM.index]);
+      setFormData(defaults);
+      setIndicesList(defaults.index ? [defaults.index] : []);
     }
     setModalOpen(true);
   };
@@ -195,7 +219,7 @@ const Integrations: React.FC = () => {
       return false;
     }
     if (!forTesting) {
-      if (!formData.index.trim()) {
+      if (connectorKind === 'elasticsearch' && !formData.index.trim()) {
         message.warning('Target index is required.');
         return false;
       }
@@ -220,16 +244,19 @@ const Integrations: React.FC = () => {
 
   // Serialize form into backend payload contract.
   const toIntegrationPayload = () => {
+    const defaults = CONNECTOR_DEFAULTS[connectorKind];
     const host = buildHostUrl();
     const cfg: any = {
       host,
-      index: formData.index.trim() || 'alerts',
-      path: formData.path.trim() || '/_cluster/health',
+      path: formData.path.trim() || defaults.path,
       protocol: formData.protocol,
       port: formData.port,
       auth_type: formData.authType,
       verify_certs: formData.protocol === 'https',
     };
+    if (connectorKind === 'elasticsearch') {
+      cfg.index = formData.index.trim() || defaults.index;
+    }
 
     if (formData.authType === 'basic') {
       cfg.username = formData.username.trim();
@@ -246,8 +273,8 @@ const Integrations: React.FC = () => {
     }
 
     return {
-      name: formData.name.trim() || 'Elastic Stack (ELK)',
-      type: 'elasticsearch',
+      name: formData.name.trim() || defaults.name,
+      type: connectorKind,
       config: cfg,
     };
   };
@@ -375,7 +402,7 @@ const Integrations: React.FC = () => {
   };
 
   type IntegrationCardConfig = {
-    key: 'elastic' | 'splunk';
+    key: 'elastic' | 'kibana' | 'splunk';
     title: string;
     subtitle: string;
     description: string;
@@ -387,6 +414,7 @@ const Integrations: React.FC = () => {
   };
 
   const elasticInstalled = Boolean(elkItems[0]?.id && elkItems[0]?.config?.host);
+  const kibanaInstalled = Boolean(kibanaItems[0]?.id && kibanaItems[0]?.config?.host);
   const integrationCards: IntegrationCardConfig[] = [
     {
       key: 'elastic',
@@ -395,8 +423,18 @@ const Integrations: React.FC = () => {
       description: 'Ingest and analyze security event logs and system metrics via automated cluster pipelines.',
       logo: '/elastic-logo.png',
       isInstalled: elasticInstalled,
-      onConfigure: () => openFromCard(elkItems[0]),
+      onConfigure: () => openFromCard('elasticsearch', elkItems[0]),
       onUninstall: elkItems[0]?.id ? () => handleDelete(elkItems[0]) : undefined,
+    },
+    {
+      key: 'kibana',
+      title: 'Kibana',
+      subtitle: 'Kibana Connector',
+      description: 'Publish detection rules and actions through Kibana APIs without configuring an ingestion target mapping.',
+      logo: '/elastic-logo.png',
+      isInstalled: kibanaInstalled,
+      onConfigure: () => openFromCard('kibana', kibanaItems[0]),
+      onUninstall: kibanaItems[0]?.id ? () => handleDelete(kibanaItems[0]) : undefined,
     },
     {
       key: 'splunk',
@@ -563,7 +601,7 @@ const Integrations: React.FC = () => {
         title={
           <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
             <img src="/elastic-logo.png" alt="Elastic logo" style={{ width: 22, height: 22, objectFit: 'contain' }} />
-            <span>Configure Elasticsearch</span>
+            <span>{connectorKind === 'kibana' ? 'Configure Kibana' : 'Configure Elasticsearch'}</span>
           </div>
         }
         open={modalOpen && !isReadonly}
@@ -699,33 +737,37 @@ const Integrations: React.FC = () => {
             </div>
           )}
 
-          <Divider style={{ margin: '2px 0' }}>Target Mapping</Divider>
+          {connectorKind === 'elasticsearch' && (
+            <>
+              <Divider style={{ margin: '2px 0' }}>Target Mapping</Divider>
 
-          <div style={{ maxWidth: 560 }}>
-            <Text strong>Target Index / Index Pattern</Text>
-            <Space.Compact style={{ width: '100%', marginTop: 6 }}>
-              <Select
-                showSearch
-                allowClear
-                value={formData.index || undefined}
-                placeholder="e.g., alerts-linux-*"
-                disabled={testing || saving}
-                loading={indicesLoading}
-                style={{ width: '100%' }}
-                options={indicesList.map((idx) => ({ label: idx, value: idx }))}
-                onChange={(v) => setField('index', String(v || ''))}
-                onSearch={(v) => setField('index', v)}
-                filterOption={(input, option) =>
-                  String(option?.label || '')
-                    .toLowerCase()
-                    .includes(input.toLowerCase())
-                }
-              />
-              <Button onClick={handleFetchIndices} loading={indicesLoading} disabled={testing || saving}>
-                Fetch Indices
-              </Button>
-            </Space.Compact>
-          </div>
+              <div style={{ maxWidth: 560 }}>
+                <Text strong>Target Index / Index Pattern</Text>
+                <Space.Compact style={{ width: '100%', marginTop: 6 }}>
+                  <Select
+                    showSearch
+                    allowClear
+                    value={formData.index || undefined}
+                    placeholder="e.g., alerts-linux-*"
+                    disabled={testing || saving}
+                    loading={indicesLoading}
+                    style={{ width: '100%' }}
+                    options={indicesList.map((idx) => ({ label: idx, value: idx }))}
+                    onChange={(v) => setField('index', String(v || ''))}
+                    onSearch={(v) => setField('index', v)}
+                    filterOption={(input, option) =>
+                      String(option?.label || '')
+                        .toLowerCase()
+                        .includes(input.toLowerCase())
+                    }
+                  />
+                  <Button onClick={handleFetchIndices} loading={indicesLoading} disabled={testing || saving}>
+                    Fetch Indices
+                  </Button>
+                </Space.Compact>
+              </div>
+            </>
+          )}
 
           <div>
             <Text type="secondary" style={{ fontSize: 12, opacity: 0.8 }}>

--- a/frontend/src/modules/tickets/components/SlaTicketDetailView.tsx
+++ b/frontend/src/modules/tickets/components/SlaTicketDetailView.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import dayjs from 'dayjs';
 import { Button, Card, Checkbox, Col, Descriptions, Divider, Empty, Form, Input, List, Modal, Row, Select, Space, Table, Tabs, Tag, Typography, message } from 'antd';
 import type { ColumnsType } from 'antd/es/table';
@@ -411,6 +411,8 @@ export default function SlaTicketDetailView(props: Props) {
   const [aiResult, setAiResult] = useState<any | null>(null);
   const [aiError, setAiError] = useState<string | null>(null);
   const [chatOpen, setChatOpen] = useState(false);
+  const [chatSize, setChatSize] = useState({ width: 320, height: 440, right: 12, top: 88 });
+  const [chatWidthTouched, setChatWidthTouched] = useState(false);
   const [chatMessages, setChatMessages] = useState<Array<{ role: string; content: string; hidden?: boolean; trace?: any[] }>>([]);
   const [chatInput, setChatInput] = useState('');
   const [chatLoading, setChatLoading] = useState(false);
@@ -437,6 +439,7 @@ export default function SlaTicketDetailView(props: Props) {
   const [newLabelName, setNewLabelName] = useState('');
   const [newLabelValue, setNewLabelValue] = useState('');
   const [labelsSaving, setLabelsSaving] = useState(false);
+  const aiAssistantCardRef = useRef<HTMLDivElement | null>(null);
 
   const notesCount = workLogs?.length ?? 0;
 
@@ -652,6 +655,18 @@ export default function SlaTicketDetailView(props: Props) {
   };
 
   const openChat = () => {
+    const anchor = aiAssistantCardRef.current?.getBoundingClientRect();
+    if (anchor) {
+      const right = Math.max(12, window.innerWidth - anchor.right);
+      const top = Math.max(12, anchor.top);
+      const maxHeight = Math.max(360, window.innerHeight - top - 12);
+      setChatSize((prev) => ({
+        width: chatWidthTouched ? prev.width : Math.max(320, Math.round(anchor.width)),
+        height: Math.min(prev.height, maxHeight),
+        right,
+        top,
+      }));
+    }
     setChatOpen(true);
     if (!chatMessages.length) {
       loadChatHistory();
@@ -1082,6 +1097,35 @@ export default function SlaTicketDetailView(props: Props) {
   }, [showEmpty, ticket]);
 
   const labelItems = useMemo(() => formatTicketLabels(editableLabels), [editableLabels]);
+  const isDarkTheme = typeof window !== 'undefined' && localStorage.getItem('siem_ui_theme') === 'dark';
+  const startChatResize = (axis: 'width' | 'height' | 'both') => (event: React.MouseEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    const startX = event.clientX;
+    const startY = event.clientY;
+    const startWidth = chatSize.width;
+    const startHeight = chatSize.height;
+    const maxWidth = Math.max(320, window.innerWidth - chatSize.right - 12);
+    const maxHeight = Math.max(360, window.innerHeight - 210);
+
+    const onMouseMove = (moveEvent: MouseEvent) => {
+      const nextWidth = axis === 'height' ? startWidth : Math.min(maxWidth, Math.max(320, startWidth + startX - moveEvent.clientX));
+      if (axis !== 'height') setChatWidthTouched(true);
+      const nextHeight = axis === 'width' ? startHeight : Math.min(maxHeight, Math.max(360, startHeight + moveEvent.clientY - startY));
+      setChatSize((prev) => ({ ...prev, width: nextWidth, height: nextHeight }));
+    };
+
+    const onMouseUp = () => {
+      document.removeEventListener('mousemove', onMouseMove);
+      document.removeEventListener('mouseup', onMouseUp);
+      document.body.style.cursor = '';
+      document.body.style.userSelect = '';
+    };
+
+    document.body.style.cursor = axis === 'width' ? 'ew-resize' : axis === 'height' ? 'ns-resize' : 'nesw-resize';
+    document.body.style.userSelect = 'none';
+    document.addEventListener('mousemove', onMouseMove);
+    document.addEventListener('mouseup', onMouseUp);
+  };
 
   const saveLabels = async (
     nextLabels: Array<{ label_name: string; label_value: string }>,
@@ -1299,7 +1343,7 @@ export default function SlaTicketDetailView(props: Props) {
                       ))}
                     </div>
                   ) : (
-                    <span style={{ color: 'rgba(0,0,0,0.35)' }}>No labels</span>
+                    <span className="sla-muted-text">No labels</span>
                   )}
                 </div>
               </Card>
@@ -1537,13 +1581,13 @@ export default function SlaTicketDetailView(props: Props) {
               </Card>
             </div>
 
-            <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+            <div ref={aiAssistantCardRef} style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
               <Card size="small" title="SOC AI Assistant">
                 <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
                   <div style={{ width: 48, height: 48, borderRadius: '50%', background: '#e6f3ff', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>AI</div>
                 <div>
                   <div style={{ fontWeight: 600 }}>AI Assistant</div>
-                  <div style={{ color: 'rgba(0,0,0,0.45)' }}>Alert interpretation and summary</div>
+                  <div className="soc-ai-assistant-subtitle">Alert interpretation and summary</div>
                 </div>
               </div>
               <div style={{ display: 'grid', gap: 8, marginTop: 12 }}>
@@ -1673,15 +1717,22 @@ export default function SlaTicketDetailView(props: Props) {
       <Modal
         title={`Chat - ${ticket.ticket_number}`}
         open={chatOpen}
+        wrapClassName={isDarkTheme ? 'sla-ai-chat-modal sla-ai-chat-modal-dark' : 'sla-ai-chat-modal'}
+        className="sla-ai-chat-drawer-modal"
         onCancel={() => setChatOpen(false)}
         footer={null}
-        width={1040}
-        styles={{ body: { maxHeight: '72vh', overflow: 'auto' } }}
+        width={chatSize.width}
+        centered={false}
+        style={{ top: chatSize.top, right: chatSize.right }}
+        styles={{ body: { padding: 0, overflow: 'hidden', height: '100%' }, content: { height: chatSize.height } }}
       >
-        <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
-          <div style={{ border: '1px solid #f0f0f0', borderRadius: 8, padding: 12, background: '#fafafa', maxHeight: 460, overflow: 'auto' }}>
+        <div className="sla-ai-chat-resize-handle sla-ai-chat-resize-left" onMouseDown={startChatResize('width')} />
+        <div className="sla-ai-chat-resize-handle sla-ai-chat-resize-bottom" onMouseDown={startChatResize('height')} />
+        <div className="sla-ai-chat-resize-handle sla-ai-chat-resize-corner" onMouseDown={startChatResize('both')} />
+        <div className="sla-ai-chat-resizable-panel">
+          <div className="sla-ai-chat-history-panel">
             <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 8 }}>
-              <Button size="small" onClick={loadMoreChatHistory} loading={chatMoreLoading} disabled={!chatNextBefore}>
+              <Button className="sla-chat-load-earlier-btn" size="small" onClick={loadMoreChatHistory} loading={chatMoreLoading} disabled={!chatNextBefore}>
                 Load earlier
               </Button>
               <Button
@@ -1731,37 +1782,37 @@ export default function SlaTicketDetailView(props: Props) {
                             )}
                           >
                             {collapsedTraces[idx] ? (
-                              <div style={{ color: '#8c8c8c' }}>Collapsed</div>
+                              <div className="sla-ai-trace-collapsed">Collapsed</div>
                             ) : (
                             <div style={{ maxHeight: 360, overflow: 'auto', display: 'flex', flexDirection: 'column', gap: 10 }}>
                               {msg.trace.map((evt: any, stepIdx: number) => {
                                 if (evt.type === 'iteration_start') {
                                   return (
-                                    <div key={`it_${stepIdx}`} style={{ padding: 10, borderLeft: '4px solid #1677ff', background: '#f0f5ff', borderRadius: 6 }}>
+                                    <div key={`it_${stepIdx}`} className="sla-ai-trace-card sla-ai-trace-card-iteration">
                                       <div style={{ fontWeight: 600 }}>Iteration {evt.iteration}</div>
                                     </div>
                                   );
                                 }
                                 if (evt.type === 'model_call') {
                                   return (
-                                    <div key={`mc_${stepIdx}`} style={{ padding: 10, borderLeft: '4px solid #8c8c8c', background: '#fafafa', borderRadius: 6 }}>
+                                    <div key={`mc_${stepIdx}`} className="sla-ai-trace-card sla-ai-trace-card-model">
                                       <div style={{ fontWeight: 600 }}>Calling AI model...</div>
                                     </div>
                                   );
                                 }
                                 if (evt.type === 'tool_calls_detected') {
                                   return (
-                                    <div key={`tc_${stepIdx}`} style={{ padding: 10, borderLeft: '4px solid #722ed1', background: '#f9f0ff', borderRadius: 6 }}>
+                                    <div key={`tc_${stepIdx}`} className="sla-ai-trace-card sla-ai-trace-card-detected">
                                       Detected {evt.count || 0} tool call(s)
                                     </div>
                                   );
                                 }
                                 if (evt.type === 'tool_call') {
                                   return (
-                                    <div key={`call_${stepIdx}`} style={{ padding: 10, borderLeft: '4px solid #fa8c16', background: '#fff7e6', borderRadius: 6 }}>
+                                    <div key={`call_${stepIdx}`} className="sla-ai-trace-card sla-ai-trace-card-call">
                                       <div style={{ fontWeight: 600 }}>Call tool: {evt.tool}</div>
-                                      <div style={{ fontSize: 12, color: '#595959', marginTop: 4 }}>{evt.endpoint || evt.source}</div>
-                                      <pre style={{ marginTop: 8, background: '#fff', border: '1px solid #f0f0f0', padding: 8, borderRadius: 6, whiteSpace: 'pre', overflow: 'auto' }}>
+                                      <div className="sla-ai-trace-meta">{evt.endpoint || evt.source}</div>
+                                      <pre className="sla-ai-trace-pre">
 {JSON.stringify(evt.arguments || {}, null, 2)}
                                       </pre>
                                     </div>
@@ -1769,13 +1820,13 @@ export default function SlaTicketDetailView(props: Props) {
                                 }
                                 if (evt.type === 'tool_result') {
                                   return (
-                                    <div key={`res_${stepIdx}`} style={{ padding: 10, borderLeft: `4px solid ${evt.success ? '#52c41a' : '#ff4d4f'}`, background: evt.success ? '#f6ffed' : '#fff1f0', borderRadius: 6 }}>
+                                    <div key={`res_${stepIdx}`} className={evt.success ? "sla-ai-trace-card sla-ai-trace-card-success" : "sla-ai-trace-card sla-ai-trace-card-error"}>
                                       <div style={{ fontWeight: 600 }}>Tool {evt.tool} {evt.success ? 'completed' : 'failed'}</div>
-                                      <pre style={{ marginTop: 8, background: '#fff', border: '1px solid #f0f0f0', padding: 8, borderRadius: 6, whiteSpace: 'pre', overflow: 'auto' }}>
+                                      <pre className="sla-ai-trace-pre">
 {String(evt.content || '')}
                                       </pre>
                                       {evt.execution_id ? (
-                                        <div style={{ marginTop: 6, fontSize: 12, color: '#8c8c8c' }}>
+                                        <div className="sla-ai-trace-meta">
                                           Execution ID: {evt.execution_id}
                                         </div>
                                       ) : null}
@@ -1784,7 +1835,7 @@ export default function SlaTicketDetailView(props: Props) {
                                 }
                                 if (evt.type === 'assistant_response') {
                                   return (
-                                    <div key={`ar_${stepIdx}`} style={{ padding: 10, borderLeft: '4px solid #13c2c2', background: '#e6fffb', borderRadius: 6 }}>
+                                    <div key={`ar_${stepIdx}`} className="sla-ai-trace-card sla-ai-trace-card-summary">
                                       <div style={{ fontWeight: 600 }}>Analysis summary</div>
                                       <div style={{ whiteSpace: 'pre-wrap', marginTop: 6 }}>{evt.content}</div>
                                     </div>
@@ -1792,7 +1843,7 @@ export default function SlaTicketDetailView(props: Props) {
                                 }
                                 if (evt.type === 'analysis_summary') {
                                   return (
-                                    <div key={`as_${stepIdx}`} style={{ padding: 10, borderLeft: '4px solid #722ed1', background: '#f9f0ff', borderRadius: 6 }}>
+                                    <div key={`as_${stepIdx}`} className="sla-ai-trace-card sla-ai-trace-card-thinking">
                                       <div style={{ fontWeight: 600 }}>AI thinking</div>
                                       <div style={{ whiteSpace: 'pre-wrap', marginTop: 6 }}>{evt.content}</div>
                                     </div>
@@ -1800,7 +1851,7 @@ export default function SlaTicketDetailView(props: Props) {
                                 }
                                 if (evt.type === 'model_error') {
                                   return (
-                                    <div key={`err_${stepIdx}`} style={{ padding: 10, borderLeft: '4px solid #ff4d4f', background: '#fff1f0', borderRadius: 6 }}>
+                                    <div key={`err_${stepIdx}`} className="sla-ai-trace-card sla-ai-trace-card-error">
                                       Model error: {evt.error}
                                     </div>
                                   );

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -1,4 +1,4 @@
-﻿/* Global CSS entry for Next.js App Router */
+/* Global CSS entry for Next.js App Router */
 
 html, body {
   padding: 0;
@@ -1759,10 +1759,40 @@ html, body {
   color: #c4b5fd;
 }
 
+.soc-ai-assistant-subtitle {
+  color: rgba(0, 0, 0, 0.45);
+}
+
+.theme-dark .soc-ai-assistant-subtitle {
+  color: #aebdda;
+}
+
+.sla-muted-text {
+  color: rgba(0, 0, 0, 0.35);
+}
+
+.theme-dark .sla-muted-text {
+  color: #8fa2c4;
+}
+
+.sla-ai-chat-history-panel {
+  border: 1px solid #f0f0f0;
+  border-radius: 8px;
+  padding: 12px;
+  background: #fafafa;
+  max-height: 460px;
+  overflow: auto;
+}
+
+.theme-dark .sla-ai-chat-history-panel,
+.sla-ai-chat-modal-dark .sla-ai-chat-history-panel {
+  border-color: rgba(101, 150, 255, 0.28);
+  background: #0b1329;
+}
+
 .theme-dark .json-token-punctuation {
   color: #b6c7e6;
 }
-
 @keyframes slaStatusBreatheBlue {
   0% {
     box-shadow: 0 0 8px rgba(47, 124, 255, 0.35);
@@ -1788,4 +1818,263 @@ html, body {
   .login-cyber-glow {
     animation: none;
   }
+}
+
+
+.theme-dark .sla-chat-load-earlier-btn.ant-btn,
+.sla-ai-chat-modal-dark .sla-chat-load-earlier-btn.ant-btn {
+  border-color: rgba(125, 211, 252, 0.36);
+  background: rgba(14, 37, 73, 0.9);
+  color: #dbeafe;
+}
+
+.theme-dark .sla-chat-load-earlier-btn.ant-btn:hover:not(:disabled),
+.sla-ai-chat-modal-dark .sla-chat-load-earlier-btn.ant-btn:hover:not(:disabled) {
+  border-color: rgba(125, 211, 252, 0.72);
+  background: rgba(20, 54, 102, 0.96);
+  color: #ffffff;
+}
+
+.theme-dark .sla-chat-load-earlier-btn.ant-btn:disabled,
+.sla-ai-chat-modal-dark .sla-chat-load-earlier-btn.ant-btn:disabled {
+  border-color: rgba(148, 163, 184, 0.18);
+  background: rgba(15, 23, 42, 0.72);
+  color: #7f8faa;
+  opacity: 1;
+}
+.sla-ai-chat-modal-dark .ant-modal-content,
+.sla-ai-chat-modal-dark .ant-modal-header {
+  background: #0b1426;
+}
+
+.sla-ai-chat-modal-dark .ant-modal-title,
+.sla-ai-chat-modal-dark .ant-modal-close {
+  color: #dbeafe;
+}
+
+.sla-ai-chat-modal-dark .ant-modal-body {
+  color: #dbeafe;
+}
+
+.sla-ai-chat-modal-dark .ant-empty-description {
+  color: #9fb1d1;
+}
+
+.sla-ai-chat-modal-dark .ant-input,
+.sla-ai-chat-modal-dark .ant-input-affix-wrapper {
+  background: #0f1b31;
+  border-color: rgba(101, 150, 255, 0.38);
+  color: #dbeafe;
+}
+
+.sla-ai-chat-modal-dark .ant-input::placeholder {
+  color: #7f8faa;
+}
+
+.sla-ai-chat-modal.ant-modal-wrap {
+  overflow: hidden;
+}
+
+.sla-ai-chat-modal .ant-modal {
+  margin: 0 0 0 auto;
+  padding-bottom: 0;
+  position: absolute;
+}
+
+.sla-ai-chat-drawer-modal.ant-modal {
+  width: 320px;
+  min-width: 320px;
+  max-width: calc(100vw - 24px);
+  min-height: 360px;
+  max-height: calc(100vh - 24px);
+}
+
+.sla-ai-chat-drawer-modal .ant-modal-content {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: hidden;
+}
+
+.sla-ai-chat-drawer-modal .ant-modal-body {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.sla-ai-chat-resizable-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  height: 100%;
+  min-height: 0;
+}
+
+.sla-ai-chat-resizable-panel .sla-ai-chat-history-panel {
+  flex: 1 1 auto;
+  min-height: 180px;
+  max-height: none;
+}
+
+.sla-ai-chat-resize-handle {
+  position: absolute;
+  z-index: 3;
+}
+
+.sla-ai-chat-resize-left {
+  top: 0;
+  bottom: 0;
+  left: -5px;
+  width: 10px;
+  cursor: ew-resize;
+}
+
+.sla-ai-chat-resize-bottom {
+  left: 0;
+  right: 0;
+  bottom: -5px;
+  height: 10px;
+  cursor: ns-resize;
+}
+
+.sla-ai-chat-resize-corner {
+  left: -7px;
+  bottom: -7px;
+  width: 18px;
+  height: 18px;
+  cursor: nesw-resize;
+}
+
+.sla-ai-chat-drawer-modal .ant-modal-content::before,
+.sla-ai-chat-drawer-modal .ant-modal-content::after {
+  content: '';
+  position: absolute;
+  pointer-events: none;
+  opacity: 0.55;
+}
+
+.sla-ai-chat-drawer-modal .ant-modal-content::before {
+  left: 0;
+  top: 0;
+  bottom: 0;
+  border-left: 2px solid rgba(125, 211, 252, 0.28);
+}
+
+.sla-ai-chat-drawer-modal .ant-modal-content::after {
+  left: 0;
+  right: 0;
+  bottom: 0;
+  border-bottom: 2px solid rgba(125, 211, 252, 0.28);
+}
+
+.sla-ai-trace-card {
+  padding: 10px;
+  border-radius: 6px;
+  border-left-width: 4px;
+  border-left-style: solid;
+}
+
+.sla-ai-trace-card-iteration {
+  border-left-color: #1677ff;
+  background: #f0f5ff;
+}
+
+.sla-ai-trace-card-model {
+  border-left-color: #8c8c8c;
+  background: #fafafa;
+}
+
+.sla-ai-trace-card-detected,
+.sla-ai-trace-card-thinking {
+  border-left-color: #722ed1;
+  background: #f9f0ff;
+}
+
+.sla-ai-trace-card-call {
+  border-left-color: #fa8c16;
+  background: #fff7e6;
+}
+
+.sla-ai-trace-card-success {
+  border-left-color: #52c41a;
+  background: #f6ffed;
+}
+
+.sla-ai-trace-card-error {
+  border-left-color: #ff4d4f;
+  background: #fff1f0;
+}
+
+.sla-ai-trace-card-summary {
+  border-left-color: #13c2c2;
+  background: #e6fffb;
+}
+
+.sla-ai-trace-meta {
+  margin-top: 4px;
+  font-size: 12px;
+  color: #595959;
+}
+
+.sla-ai-trace-pre {
+  margin-top: 8px;
+  background: #fff;
+  border: 1px solid #f0f0f0;
+  padding: 8px;
+  border-radius: 6px;
+  white-space: pre;
+  overflow: auto;
+}
+
+.sla-ai-chat-modal-dark .sla-ai-trace-card {
+  color: #dbeafe;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.03);
+}
+
+.sla-ai-chat-modal-dark .sla-ai-trace-card-iteration {
+  background: rgba(22, 119, 255, 0.16);
+}
+
+.sla-ai-chat-modal-dark .sla-ai-trace-card-model {
+  background: rgba(148, 163, 184, 0.12);
+}
+
+.sla-ai-chat-modal-dark .sla-ai-trace-card-detected,
+.sla-ai-chat-modal-dark .sla-ai-trace-card-thinking {
+  background: rgba(114, 46, 209, 0.16);
+}
+
+.sla-ai-chat-modal-dark .sla-ai-trace-card-call {
+  background: rgba(250, 140, 22, 0.16);
+}
+
+.sla-ai-chat-modal-dark .sla-ai-trace-card-success {
+  background: rgba(82, 196, 26, 0.16);
+}
+
+.sla-ai-chat-modal-dark .sla-ai-trace-card-error {
+  background: rgba(255, 77, 79, 0.16);
+}
+
+.sla-ai-chat-modal-dark .sla-ai-trace-card-summary {
+  background: rgba(19, 194, 194, 0.16);
+}
+
+.sla-ai-chat-modal-dark .sla-ai-trace-meta {
+  color: #9fb1d1;
+}
+
+.sla-ai-chat-modal-dark .sla-ai-trace-pre {
+  background: #0f1b31;
+  border-color: rgba(101, 150, 255, 0.28);
+  color: #dbeafe;
+}
+
+.sla-ai-trace-collapsed {
+  color: #6b7280;
+  font-size: 12px;
+}
+
+.sla-ai-chat-modal-dark .sla-ai-trace-collapsed {
+  color: #c7d2fe;
 }


### PR DESCRIPTION
This PR adds a dedicated Kibana connector alongside the existing ELK connector in Integrations.
Main changes:
Adds a new Kibana Connector card in Settings > Integrations.
Reuses the existing ELK connection/auth modal logic, but switches defaults for Kibana:default port: 5601
default test path: /api/status
saved integration type: kibana

Removes Target Mapping from the Kibana connector flow. The target index/index pattern and Fetch Indices UI remain only for the Elasticsearch connector.
Updates backend integration validation to allow both elasticsearch and kibana integration types.
Updates Kibana publishing service to prefer a configured kibana integration, while keeping fallback compatibility with the existing elasticsearch connector.