### PR TITLE
feat(workflow): secure secrets and published execution lifecycle

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -20,3 +20,4 @@ openpyxl
 prefect
 pysigma>=1.3.3,<2.0.0
 pySigma-backend-elasticsearch>=2.0.3,<3.0.0
+cryptography>=44.0.0

--- a/backend/siem_project/settings.py
+++ b/backend/siem_project/settings.py
@@ -63,6 +63,24 @@ ALLOWED_HOSTS = _env_list('ALLOWED_HOSTS', 'localhost,127.0.0.1')
 if not DEBUG and '*' in ALLOWED_HOSTS:
     raise ImproperlyConfigured('ALLOWED_HOSTS must not contain "*" when DEBUG=False.')
 
+# Workflow action credentials use a dedicated key ring. The first key is used
+# for encryption; the rest are decryption-only fallbacks during key rotation.
+WORKFLOW_ENCRYPTION_KEYS = _env_list('WORKFLOW_ENCRYPTION_KEYS')
+if not DEBUG:
+    if not WORKFLOW_ENCRYPTION_KEYS:
+        raise ImproperlyConfigured(
+            'WORKFLOW_ENCRYPTION_KEYS must contain at least one Fernet key when DEBUG=False.'
+        )
+    try:
+        from cryptography.fernet import Fernet
+
+        for workflow_encryption_key in WORKFLOW_ENCRYPTION_KEYS:
+            Fernet(workflow_encryption_key.encode('ascii'))
+    except (ImportError, TypeError, ValueError) as exc:
+        raise ImproperlyConfigured(
+            'WORKFLOW_ENCRYPTION_KEYS contains an invalid Fernet key or cryptography is unavailable.'
+        ) from exc
+
 CSRF_TRUSTED_ORIGINS = _env_list('CSRF_TRUSTED_ORIGINS')
 
 # Production security hardening. Keep redirect/HSTS configurable because some

--- a/backend/workflows/actions.py
+++ b/backend/workflows/actions.py
@@ -14,12 +14,14 @@ Action categories:
   - utility      : Log, Delay
 """
 import json
+import ipaddress
 import logging
 import re
 import requests
 import time
 from abc import ABC, abstractmethod
 from typing import Any, Dict, Optional
+from urllib.parse import quote, urlparse
 from django.conf import settings
 from django.core.mail import send_mail
 from django.utils import timezone
@@ -320,6 +322,9 @@ class SendWebhookAction(BaseAction):
             "headers": {
                 "type": "object",
                 "description": "Request headers (key-value pairs)",
+                "writeOnly": True,
+                "x-sensitive": True,
+                "x-secret-bindings": ["url"],
             },
             "body_template": {
                 "type": "string",
@@ -788,6 +793,9 @@ class IPLookupAction(BaseAction):
             "api_key": {
                 "type": "string",
                 "description": "API key for the threat-intelligence platform",
+                "writeOnly": True,
+                "x-sensitive": True,
+                "x-secret-bindings": ["api_url"],
             },
             "timeout": {"type": "integer", "default": 15},
         },
@@ -908,6 +916,9 @@ class HashLookupAction(BaseAction):
             "api_key": {
                 "type": "string",
                 "description": "API key for the threat-intelligence platform",
+                "writeOnly": True,
+                "x-sensitive": True,
+                "x-secret-bindings": ["api_url"],
             },
             "timeout": {"type": "integer", "default": 15},
         },
@@ -985,6 +996,168 @@ class HashLookupAction(BaseAction):
 
 # ============ Containment Actions ============
 
+_OPNSENSE_ALIAS_PATTERN = re.compile(r"^[A-Za-z0-9_][A-Za-z0-9_.-]{0,31}$")
+
+
+def _boolean_config(value: Any, default: bool) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "on"}
+    return bool(value)
+
+
+def _opnsense_alias_action(
+    *,
+    operation: str,
+    ip: str,
+    api_url: str,
+    api_key: str,
+    api_secret: str,
+    alias_name: str,
+    timeout: int,
+    verify_tls: bool,
+    kill_states: bool = False,
+) -> ActionResult:
+    """Add/delete an address using the OPNsense alias utility API."""
+    try:
+        normalised_ip = str(ipaddress.ip_address(str(ip).strip()))
+    except ValueError:
+        return ActionResult(success=False, error="ip_address is not a valid IPv4 or IPv6 address")
+
+    parsed_url = urlparse(api_url.strip())
+    if parsed_url.scheme.lower() != "https" or not parsed_url.netloc:
+        return ActionResult(success=False, error="OPNsense api_url must be an absolute HTTPS URL")
+    if (
+        parsed_url.username
+        or parsed_url.password
+        or parsed_url.query
+        or parsed_url.fragment
+        or parsed_url.path not in {"", "/"}
+    ):
+        return ActionResult(
+            success=False,
+            error="OPNsense api_url must be a base URL without credentials, path, query, or fragment",
+        )
+    base_url = api_url.strip().rstrip("/")
+    alias_name = alias_name.strip()
+    if not _OPNSENSE_ALIAS_PATTERN.fullmatch(alias_name):
+        return ActionResult(
+            success=False,
+            error="alias_name must be 1-32 characters using letters, numbers, underscore, dot, or hyphen",
+        )
+    if not api_key or not api_secret:
+        return ActionResult(success=False, error="OPNsense api_key and api_secret are required")
+    if operation not in {"add", "delete"}:
+        return ActionResult(success=False, error="Unsupported OPNsense alias operation")
+
+    endpoint = f"{base_url}/api/firewall/alias_util/{operation}/{quote(alias_name, safe='')}"
+    if not verify_tls:
+        logger.warning(
+            "[SECURITY] OPNsense TLS certificate verification is disabled for host %s",
+            parsed_url.hostname,
+        )
+
+    try:
+        response = requests.post(
+            endpoint,
+            auth=(api_key, api_secret),
+            json={"address": normalised_ip},
+            timeout=timeout,
+            verify=verify_tls,
+            allow_redirects=False,
+        )
+        try:
+            response_payload = response.json() if response.content else {}
+        except ValueError:
+            response_payload = {}
+        business_success = (
+            200 <= response.status_code < 300
+            and isinstance(response_payload, dict)
+            and response_payload.get("status") == "done"
+        )
+        result_data = {
+            "provider": "opnsense",
+            "ip": normalised_ip,
+            "alias_name": alias_name,
+            "operation": operation,
+            "status_code": response.status_code,
+            "api_status": response_payload.get("status") if isinstance(response_payload, dict) else None,
+            "state_cleanup": {"requested": False},
+        }
+
+        if not business_success:
+            return ActionResult(
+                success=False,
+                data=result_data,
+                error=(
+                    f"OPNsense alias {operation} failed: HTTP {response.status_code}, "
+                    f"status={result_data['api_status']!r}"
+                ),
+                logs=f"OPNsense alias {operation} for {normalised_ip} was not completed",
+            )
+
+        cleanup_warning = ""
+        if operation == "add" and kill_states:
+            cleanup_endpoint = f"{base_url}/api/diagnostics/firewall/kill_states"
+            try:
+                cleanup = requests.post(
+                    cleanup_endpoint,
+                    auth=(api_key, api_secret),
+                    json={"filter": normalised_ip},
+                    timeout=timeout,
+                    verify=verify_tls,
+                    allow_redirects=False,
+                )
+                try:
+                    cleanup_payload = cleanup.json() if cleanup.content else {}
+                except ValueError:
+                    cleanup_payload = {}
+                cleanup_status = cleanup_payload.get("status") if isinstance(cleanup_payload, dict) else None
+                cleanup_success = (
+                    200 <= cleanup.status_code < 300
+                    and cleanup_status in {"done", "ok"}
+                )
+                result_data["state_cleanup"] = {
+                    "requested": True,
+                    "success": cleanup_success,
+                    "status_code": cleanup.status_code,
+                    "api_status": cleanup_status,
+                }
+            except requests.RequestException as exc:
+                cleanup_success = False
+                result_data["state_cleanup"] = {
+                    "requested": True,
+                    "success": False,
+                    "error": exc.__class__.__name__,
+                }
+            if not cleanup_success:
+                cleanup_warning = "State cleanup failed after the IP was blocked"
+                logger.warning(
+                    "OPNsense state cleanup failed for %s",
+                    normalised_ip,
+                )
+
+        past_tense = "blocked" if operation == "add" else "released"
+        result_data[past_tense] = True
+        result_data[f"{past_tense}_at"] = timezone.now().isoformat()
+        if cleanup_warning:
+            result_data["warning"] = cleanup_warning
+        return ActionResult(
+            success=True,
+            data=result_data,
+            logs=(
+                f"OPNsense {past_tense} {normalised_ip} in alias {alias_name}"
+                + (f"; warning: {cleanup_warning}" if cleanup_warning else "")
+            ),
+        )
+    except requests.RequestException as exc:
+        return ActionResult(
+            success=False,
+            error=f"OPNsense request failed: {exc.__class__.__name__}",
+            logs=f"OPNsense alias {operation} request failed for {normalised_ip}",
+        )
+
 class BlockIPAction(BaseAction):
     """Block an IP address via an external security-device API.
 
@@ -1007,6 +1180,12 @@ class BlockIPAction(BaseAction):
     config_schema = {
         "type": "object",
         "properties": {
+            "provider": {
+                "type": "string",
+                "enum": ["generic", "opnsense"],
+                "default": "generic",
+                "description": "Security-device API provider",
+            },
             "ip_address": {
                 "type": "string",
                 "description": (
@@ -1021,6 +1200,33 @@ class BlockIPAction(BaseAction):
             "api_key": {
                 "type": "string",
                 "description": "API key / token for the security device",
+                "writeOnly": True,
+                "x-sensitive": True,
+                "x-secret-bindings": ["provider", "api_url", "alias_name"],
+                "x-secret-rebindable": ["alias_name"],
+            },
+            "api_secret": {
+                "type": "string",
+                "description": "OPNsense API secret",
+                "writeOnly": True,
+                "x-sensitive": True,
+                "x-secret-bindings": ["provider", "api_url", "alias_name"],
+                "x-secret-rebindable": ["alias_name"],
+            },
+            "alias_name": {
+                "type": "string",
+                "default": "ARGUS_BLOCKLIST",
+                "description": "OPNsense firewall alias name",
+            },
+            "verify_tls": {
+                "type": "boolean",
+                "default": True,
+                "description": "Verify the OPNsense TLS certificate",
+            },
+            "kill_states": {
+                "type": "boolean",
+                "default": False,
+                "description": "Kill active firewall states after a successful block",
             },
             "duration_hours": {
                 "type": "integer",
@@ -1037,14 +1243,19 @@ class BlockIPAction(BaseAction):
     }
 
     def execute(self, config: Dict, context: Dict) -> ActionResult:
+        provider = str(config.get("provider") or "generic").strip().lower()
         ip = self.resolve_variables(config.get("ip_address", ""), context)
         api_url = self.resolve_variables(config.get("api_url", ""), context)
         api_key = self.resolve_variables(config.get("api_key", ""), context)
+        api_secret = self.resolve_variables(config.get("api_secret", ""), context)
         duration = config.get("duration_hours", 24)
         reason = self.resolve_variables(
             config.get("reason", "Blocked by SOAR workflow"), context
         )
-        timeout = int(config.get("timeout", 15))
+        try:
+            timeout = int(config.get("timeout", 15))
+        except (TypeError, ValueError):
+            return ActionResult(success=False, error="timeout must be an integer number of seconds")
 
         if not ip:
             return ActionResult(
@@ -1052,6 +1263,21 @@ class BlockIPAction(BaseAction):
                 error="ip_address is empty after variable resolution",
                 logs="Block IP aborted: no IP address provided",
             )
+
+        if provider == "opnsense":
+            return _opnsense_alias_action(
+                operation="add",
+                ip=ip,
+                api_url=api_url,
+                api_key=api_key,
+                api_secret=api_secret,
+                alias_name=str(config.get("alias_name") or "ARGUS_BLOCKLIST"),
+                timeout=max(1, min(timeout, 120)),
+                verify_tls=_boolean_config(config.get("verify_tls"), True),
+                kill_states=_boolean_config(config.get("kill_states"), False),
+            )
+        if provider != "generic":
+            return ActionResult(success=False, error=f"Unsupported Block IP provider: {provider}")
 
         try:
             response = requests.post(
@@ -1128,6 +1354,9 @@ class DisableUserAction(BaseAction):
             "api_key": {
                 "type": "string",
                 "description": "API key / token for the security device",
+                "writeOnly": True,
+                "x-sensitive": True,
+                "x-secret-bindings": ["api_url"],
             },
             "reason": {
                 "type": "string",
@@ -1145,7 +1374,10 @@ class DisableUserAction(BaseAction):
         reason = self.resolve_variables(
             config.get("reason", "Disabled by SOAR workflow"), context
         )
-        timeout = int(config.get("timeout", 15))
+        try:
+            timeout = int(config.get("timeout", 15))
+        except (TypeError, ValueError):
+            return ActionResult(success=False, error="timeout must be an integer number of seconds")
 
         if not username:
             return ActionResult(
@@ -1213,6 +1445,12 @@ class ReleaseIPAction(BaseAction):
     config_schema = {
         "type": "object",
         "properties": {
+            "provider": {
+                "type": "string",
+                "enum": ["generic", "opnsense"],
+                "default": "generic",
+                "description": "Security-device API provider",
+            },
             "ip_address": {
                 "type": "string",
                 "description": (
@@ -1227,6 +1465,28 @@ class ReleaseIPAction(BaseAction):
             "api_key": {
                 "type": "string",
                 "description": "API key / token for the security device",
+                "writeOnly": True,
+                "x-sensitive": True,
+                "x-secret-bindings": ["provider", "api_url", "alias_name"],
+                "x-secret-rebindable": ["alias_name"],
+            },
+            "api_secret": {
+                "type": "string",
+                "description": "OPNsense API secret",
+                "writeOnly": True,
+                "x-sensitive": True,
+                "x-secret-bindings": ["provider", "api_url", "alias_name"],
+                "x-secret-rebindable": ["alias_name"],
+            },
+            "alias_name": {
+                "type": "string",
+                "default": "ARGUS_BLOCKLIST",
+                "description": "OPNsense firewall alias name",
+            },
+            "verify_tls": {
+                "type": "boolean",
+                "default": True,
+                "description": "Verify the OPNsense TLS certificate",
             },
             "reason": {
                 "type": "string",
@@ -1238,13 +1498,18 @@ class ReleaseIPAction(BaseAction):
     }
 
     def execute(self, config: Dict, context: Dict) -> ActionResult:
+        provider = str(config.get("provider") or "generic").strip().lower()
         ip = self.resolve_variables(config.get("ip_address", ""), context)
         api_url = self.resolve_variables(config.get("api_url", ""), context)
         api_key = self.resolve_variables(config.get("api_key", ""), context)
+        api_secret = self.resolve_variables(config.get("api_secret", ""), context)
         reason = self.resolve_variables(
             config.get("reason", "Released by SOAR workflow"), context
         )
-        timeout = int(config.get("timeout", 15))
+        try:
+            timeout = int(config.get("timeout", 15))
+        except (TypeError, ValueError):
+            return ActionResult(success=False, error="timeout must be an integer number of seconds")
 
         if not ip:
             return ActionResult(
@@ -1252,6 +1517,20 @@ class ReleaseIPAction(BaseAction):
                 error="ip_address is empty after variable resolution",
                 logs="Release IP aborted: no IP address provided",
             )
+
+        if provider == "opnsense":
+            return _opnsense_alias_action(
+                operation="delete",
+                ip=ip,
+                api_url=api_url,
+                api_key=api_key,
+                api_secret=api_secret,
+                alias_name=str(config.get("alias_name") or "ARGUS_BLOCKLIST"),
+                timeout=max(1, min(timeout, 120)),
+                verify_tls=_boolean_config(config.get("verify_tls"), True),
+            )
+        if provider != "generic":
+            return ActionResult(success=False, error=f"Unsupported Release IP provider: {provider}")
 
         try:
             response = requests.post(
@@ -1325,6 +1604,9 @@ class EnableUserAction(BaseAction):
             "api_key": {
                 "type": "string",
                 "description": "API key / token for the security device",
+                "writeOnly": True,
+                "x-sensitive": True,
+                "x-secret-bindings": ["api_url"],
             },
             "reason": {
                 "type": "string",

--- a/backend/workflows/engine.py
+++ b/backend/workflows/engine.py
@@ -30,8 +30,31 @@ from .condition_evaluator import (
     extract_condition_fields as shared_extract_condition_fields,
     normalize_condition_field as shared_normalize_condition_field,
 )
+from .secret_config import decrypt_config_for_execution, redact_values, sensitive_fields
 
 logger = logging.getLogger(__name__)
+
+
+class WorkflowExecutionUnavailable(ValueError):
+    """Raised before an execution is created when a workflow cannot run."""
+
+
+def ensure_workflow_is_runnable(workflow: Workflow) -> None:
+    if not workflow.is_active:
+        raise WorkflowExecutionUnavailable('Workflow must be active before execution.')
+
+    from .publisher import load_current_published_manifest
+
+    try:
+        load_current_published_manifest(workflow)
+    except FileNotFoundError as exc:
+        raise WorkflowExecutionUnavailable(
+            'Workflow must be published before execution.'
+        ) from exc
+    except (OSError, ValueError, TypeError, KeyError) as exc:
+        raise WorkflowExecutionUnavailable(
+            'Published workflow manifest is unavailable or invalid; publish the workflow again.'
+        ) from exc
 
 
 class WorkflowEngine:
@@ -168,6 +191,7 @@ class WorkflowEngine:
         step_exec = self._create_step_execution(step, 'running', attempt)
         step_exec.input_data = self.context.copy()
         step_exec.save()
+        secrets = []
 
         try:
             # Get the action handler
@@ -179,8 +203,17 @@ class WorkflowEngine:
                 config.update(step.action_template.default_config)
             config.update(step.action_config)
 
-            # Execute the action
-            result = action.execute(config, self.context)
+            # Credentials remain encrypted in ORM and execution history. Only
+            # this short-lived copy is decrypted immediately before execution.
+            execution_config = decrypt_config_for_execution(step.action_type, config)
+            secrets = [
+                execution_config.get(field)
+                for field in sensitive_fields(step.action_type)
+            ]
+            result = action.execute(execution_config, self.context)
+            result.data = redact_values(result.data, secrets)
+            result.error = redact_values(result.error, secrets)
+            result.logs = redact_values(result.logs, secrets)
 
             # Update step execution
             step_exec.status = 'completed' if result.success else 'failed'
@@ -194,14 +227,15 @@ class WorkflowEngine:
             return result
 
         except Exception as e:
-            logger.exception(f"Step execution error: {step.name}")
+            safe_error = redact_values(str(e), secrets)
+            logger.error("Step execution error for %s: %s", step.name, safe_error)
             step_exec.status = 'failed'
             step_exec.completed_at = timezone.now()
-            step_exec.error_message = str(e)
-            step_exec.error_traceback = traceback.format_exc()
+            step_exec.error_message = safe_error
+            step_exec.error_traceback = redact_values(traceback.format_exc(), secrets)
             step_exec.save()
 
-            return ActionResult(success=False, error=str(e))
+            return ActionResult(success=False, error=safe_error)
 
     def _create_step_execution(
         self,
@@ -428,7 +462,11 @@ def execute_workflow(
     Returns:
         The ``WorkflowExecution`` record (already persisted).
     """
-    # Create the execution record in PENDING state before dispatching.
+    # A draft may have unpublished changes and is still runnable using its last
+    # published snapshot. The manifest itself, not is_draft, is authoritative.
+    ensure_workflow_is_runnable(workflow)
+
+    # Create the execution record in PENDING state only after preflight passes.
     execution = WorkflowExecution.objects.create(
         workflow=workflow,
         trigger_source=trigger_source,

--- a/backend/workflows/flows/generic_workflow_flow.py
+++ b/backend/workflows/flows/generic_workflow_flow.py
@@ -21,7 +21,10 @@ import django
 
 django.setup()
 
+from django.utils import timezone
+
 from workflows.condition_evaluator import evaluate_condition_object, resolve_context_path
+from workflows.models import StepExecution, WorkflowExecution, WorkflowStep
 from workflows.tasks import (
     block_ip_task,
     create_ticket_task,
@@ -116,6 +119,121 @@ def _update_context_after_step(
     }
 
 
+def _mark_execution_running(
+    execution_id: str,
+    *,
+    total_steps: int,
+    context: Dict[str, Any],
+) -> None:
+    """Keep the Argus execution row authoritative while Prefect runs it."""
+    execution = WorkflowExecution.objects.get(id=execution_id)
+    execution.status = 'running'
+    execution.started_at = execution.started_at or timezone.now()
+    execution.completed_at = None
+    execution.error_message = ''
+    execution.total_steps = total_steps
+    execution.context = context
+    execution.save(update_fields=[
+        'status', 'started_at', 'completed_at', 'error_message',
+        'total_steps', 'context', 'updated_at',
+    ])
+
+
+def _persist_step_result(
+    execution_id: str,
+    entry: Dict[str, Any],
+    *,
+    context: Dict[str, Any],
+    current_step: int,
+) -> None:
+    """Write one Prefect step result back to Django immediately."""
+    execution = WorkflowExecution.objects.select_related('workflow').get(id=execution_id)
+    try:
+        step = WorkflowStep.objects.get(
+            id=entry.get('step_id'),
+            workflow=execution.workflow,
+        )
+    except (WorkflowStep.DoesNotExist, ValueError, TypeError):
+        return
+
+    now = timezone.now()
+    StepExecution.objects.update_or_create(
+        workflow_execution=execution,
+        step=step,
+        defaults={
+            'status': entry.get('status') or 'completed',
+            'attempt_number': max(int(entry.get('attempt_number') or 1), 1),
+            'started_at': now,
+            'completed_at': now,
+            'input_data': entry.get('input_data') or {},
+            'output_data': entry.get('output_data') or {},
+            'error_message': entry.get('error_message') or '',
+            'logs': entry.get('logs') or '',
+        },
+    )
+
+    processed_count = execution.step_executions.filter(
+        status__in=('completed', 'failed', 'skipped', 'cancelled'),
+    ).count()
+    execution.current_step = max(current_step, 0)
+    execution.completed_steps = min(processed_count, execution.total_steps)
+    execution.update_progress()
+    execution.context = context
+    execution.save(update_fields=[
+        'current_step', 'completed_steps', 'progress_percent', 'context', 'updated_at',
+    ])
+
+
+def _mark_execution_finished(
+    execution_id: str,
+    *,
+    status: str,
+    results: List[Dict[str, Any]],
+    context: Dict[str, Any],
+    error: str = '',
+) -> Dict[str, Any]:
+    payload = {
+        'execution_id': execution_id,
+        'status': status,
+        'step_results': results,
+    }
+    if error:
+        payload['error'] = error
+
+    execution = WorkflowExecution.objects.get(id=execution_id)
+    execution.status = status
+    execution.completed_at = timezone.now()
+    execution.error_message = error
+    execution.context = context
+    execution.result_data = payload
+    if status == 'completed':
+        execution.completed_steps = execution.total_steps
+        execution.progress_percent = 100.0 if execution.total_steps else 0.0
+    execution.save(update_fields=[
+        'status', 'completed_at', 'error_message', 'context', 'result_data',
+        'completed_steps', 'progress_percent', 'updated_at',
+    ])
+    return payload
+
+
+def _fail_execution(
+    execution_id: str,
+    *,
+    results: List[Dict[str, Any]],
+    context: Dict[str, Any],
+    error: str,
+) -> None:
+    """Persist a business failure and make Prefect report a FAILED run."""
+    _mark_execution_finished(
+        execution_id,
+        status='failed',
+        results=results,
+        context=context,
+        error=error,
+    )
+    raise RuntimeError(error)
+
+
 @flow(name='soar-generic')
 def run_soar_workflow(
     manifest_ref: str,
@@ -146,12 +264,14 @@ def run_soar_workflow(
     }
 
     steps = list(workflow_definition.get('steps', []) or [])
+    _mark_execution_running(execution_id, total_steps=len(steps), context=context)
     if not steps:
-        return {
-            'execution_id': execution_id,
-            'status': 'completed',
-            'step_results': [],
-        }
+        return _mark_execution_finished(
+            execution_id,
+            status='completed',
+            results=[],
+            context=context,
+        )
 
     steps_by_id = {str(step.get('id')): step for step in steps if step.get('id')}
     ordered_steps = sorted(steps, key=lambda item: item.get('order', 0))
@@ -167,20 +287,25 @@ def run_soar_workflow(
     while current_step_id:
         iterations += 1
         if iterations > max_iterations:
-            return {
-                'execution_id': execution_id,
-                'status': 'failed',
-                'step_results': results,
-                'error': 'Workflow exceeded max iteration limit; possible loop in graph.',
-            }
+            _fail_execution(
+                execution_id,
+                results=results,
+                context=context,
+                error='Workflow exceeded max iteration limit; possible loop in graph.',
+            )
 
         step = steps_by_id.get(str(current_step_id))
         if not step:
-            break
+            _fail_execution(
+                execution_id,
+                results=results,
+                context=context,
+                error=f'Workflow references missing step: {current_step_id}',
+            )
 
         node_type = step.get('node_type')
         if node_type in ('start', 'end'):
-            results.append({
+            step_result = {
                 'step_id': step.get('id'),
                 'status': 'skipped',
                 'attempt_number': 1,
@@ -188,7 +313,14 @@ def run_soar_workflow(
                 'output_data': {},
                 'error_message': '',
                 'logs': f'skipped {node_type} node',
-            })
+            }
+            results.append(step_result)
+            _persist_step_result(
+                execution_id,
+                step_result,
+                context=context,
+                current_step=iterations - 1,
+            )
             if node_type == 'end':
                 break
             current_step_id = _next_step_id(ordered_steps, order_index, step)
@@ -226,12 +358,19 @@ def run_soar_workflow(
                 _update_context_after_step(context, step.get('id'), False, {})
 
             results.append(step_result)
+            _persist_step_result(
+                execution_id,
+                step_result,
+                context=context,
+                current_step=iterations - 1,
+            )
             if step_result.get('status') == 'failed' and step.get('on_failure') == 'stop':
-                return {
-                    'execution_id': execution_id,
-                    'status': 'failed',
-                    'step_results': results,
-                }
+                _fail_execution(
+                    execution_id,
+                    results=results,
+                    context=context,
+                    error=step_result.get('error_message') or f"Condition step '{step.get('name')}' failed.",
+                )
 
             current_step_id = _next_step_id(ordered_steps, order_index, step, condition_result=condition_result)
             continue
@@ -239,7 +378,7 @@ def run_soar_workflow(
         action_type = step.get('action_type')
         action_task = ACTION_TASKS.get(action_type)
         if not action_task:
-            results.append({
+            step_result = {
                 'step_id': step.get('id'),
                 'status': 'failed',
                 'attempt_number': 1,
@@ -247,13 +386,22 @@ def run_soar_workflow(
                 'output_data': {},
                 'error_message': f'Unknown action type: {action_type}',
                 'logs': 'No task mapped for action type',
-            })
+            }
+            results.append(step_result)
+            _update_context_after_step(context, step.get('id'), False, {})
+            _persist_step_result(
+                execution_id,
+                step_result,
+                context=context,
+                current_step=iterations - 1,
+            )
             if step.get('on_failure') == 'stop':
-                return {
-                    'execution_id': execution_id,
-                    'status': 'failed',
-                    'step_results': results,
-                }
+                _fail_execution(
+                    execution_id,
+                    results=results,
+                    context=context,
+                    error=step_result['error_message'],
+                )
             current_step_id = _next_step_id(ordered_steps, order_index, step)
             continue
 
@@ -272,7 +420,7 @@ def run_soar_workflow(
         success = bool(action_result.get('success', True)) if isinstance(action_result, dict) else True
         attempt_number = 1
 
-        results.append({
+        step_result = {
             'step_id': step.get('id'),
             'status': 'completed' if success else 'failed',
             'attempt_number': attempt_number,
@@ -280,20 +428,29 @@ def run_soar_workflow(
             'output_data': output_data,
             'error_message': action_result.get('error', '') if isinstance(action_result, dict) else '',
             'logs': action_result.get('logs', '') if isinstance(action_result, dict) else '',
-        })
+        }
+        results.append(step_result)
         _update_context_after_step(context, step.get('id'), success, output_data)
+        _persist_step_result(
+            execution_id,
+            step_result,
+            context=context,
+            current_step=iterations - 1,
+        )
 
         if success is False and step.get('on_failure') == 'stop':
-            return {
-                'execution_id': execution_id,
-                'status': 'failed',
-                'step_results': results,
-            }
+            _fail_execution(
+                execution_id,
+                results=results,
+                context=context,
+                error=step_result.get('error_message') or f"Action step '{step.get('name')}' failed.",
+            )
 
         current_step_id = _next_step_id(ordered_steps, order_index, step)
 
-    return {
-        'execution_id': execution_id,
-        'status': 'completed',
-        'step_results': results,
-    }
+    return _mark_execution_finished(
+        execution_id,
+        status='completed',
+        results=results,
+        context=context,
+    )

--- a/backend/workflows/management/commands/migrate_workflow_secrets.py
+++ b/backend/workflows/management/commands/migrate_workflow_secrets.py
@@ -1,0 +1,147 @@
+"""Encrypt or rotate sensitive workflow action configuration."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from django.core.management.base import BaseCommand, CommandError
+from django.core.exceptions import ImproperlyConfigured
+from django.db import transaction
+
+from workflows.models import ActionTemplate, SavedWorkflowNode, StepExecution, Workflow, WorkflowStep
+from workflows.publisher import GENERATED_FLOWS_DIR, _atomic_write_json, publish_workflow
+from workflows.secret_config import (
+    SecretConfigError,
+    prepare_config_for_storage,
+    rotate_config,
+)
+
+
+class Command(BaseCommand):
+    help = (
+        "Encrypt plaintext workflow secrets in database rows and Prefect manifests. "
+        "The command is a dry-run unless --apply is supplied."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--apply",
+            action="store_true",
+            help="Persist the validated changes. Without this flag no writes occur.",
+        )
+        parser.add_argument(
+            "--rotate",
+            action="store_true",
+            help="Re-encrypt existing ciphertext with the first WORKFLOW_ENCRYPTION_KEYS key.",
+        )
+        parser.add_argument(
+            "--skip-publish",
+            action="store_true",
+            help="Do not publish a fresh version of currently published Prefect workflows.",
+        )
+
+    @staticmethod
+    def _secure(action_type, config, rotate):
+        secured = prepare_config_for_storage(action_type or "", config or {})
+        return rotate_config(action_type or "", secured) if rotate else secured
+
+    def _collect_database_changes(self, rotate):
+        changes = []
+        for item in ActionTemplate.objects.all().iterator():
+            secured = self._secure(item.action_type, item.default_config, rotate)
+            if secured != (item.default_config or {}):
+                changes.append((ActionTemplate, item.pk, "default_config", secured))
+
+        for item in WorkflowStep.objects.all().iterator():
+            secured = self._secure(item.action_type, item.action_config, rotate)
+            if secured != (item.action_config or {}):
+                changes.append((WorkflowStep, item.pk, "action_config", secured))
+
+        for item in SavedWorkflowNode.objects.all().iterator():
+            secured = self._secure(item.action_type, item.action_config, rotate)
+            if secured != (item.action_config or {}):
+                changes.append((SavedWorkflowNode, item.pk, "action_config", secured))
+
+        for item in StepExecution.objects.select_related("step").all().iterator():
+            current = item.input_data or {}
+            if isinstance(current.get("action_config"), dict):
+                secured = dict(current)
+                secured["action_config"] = self._secure(
+                    item.step.action_type, current["action_config"], rotate
+                )
+            else:
+                secured = self._secure(item.step.action_type, current, rotate)
+            if secured != current:
+                changes.append((StepExecution, item.pk, "input_data", secured))
+        return changes
+
+    def _collect_manifest_changes(self, rotate):
+        changes = []
+        if not GENERATED_FLOWS_DIR.exists():
+            return changes
+        for path in sorted(GENERATED_FLOWS_DIR.glob("*/v*.json")):
+            try:
+                with path.open("r", encoding="utf-8") as handle:
+                    payload = json.load(handle)
+            except (OSError, json.JSONDecodeError) as exc:
+                raise CommandError(f"Cannot read workflow manifest {path}: {exc}") from exc
+
+            secured_payload = dict(payload)
+            secured_steps = []
+            changed = False
+            for step in payload.get("steps") or []:
+                secured_step = dict(step)
+                config = step.get("action_config") or {}
+                secured_config = self._secure(step.get("action_type") or "", config, rotate)
+                secured_step["action_config"] = secured_config
+                secured_steps.append(secured_step)
+                changed = changed or secured_config != config
+            secured_payload["steps"] = secured_steps
+            if changed:
+                changes.append((path, secured_payload))
+        return changes
+
+    def handle(self, *args, **options):
+        apply_changes = bool(options["apply"])
+        rotate = bool(options["rotate"])
+        try:
+            database_changes = self._collect_database_changes(rotate)
+            manifest_changes = self._collect_manifest_changes(rotate)
+        except (SecretConfigError, ImproperlyConfigured, ValueError) as exc:
+            raise CommandError(str(exc)) from exc
+
+        published_workflows = list(
+            Workflow.objects.filter(execution_engine="prefect", is_draft=False)
+        ) if (database_changes or manifest_changes) else []
+        self.stdout.write(
+            f"Database rows to rewrite: {len(database_changes)}; "
+            f"manifest files to rewrite: {len(manifest_changes)}; "
+            f"workflows to republish: {0 if options['skip_publish'] else len(published_workflows)}"
+        )
+
+        if not apply_changes:
+            self.stdout.write(self.style.WARNING("Dry-run only; no data was changed."))
+            return
+
+        try:
+            with transaction.atomic():
+                for model, pk, field, value in database_changes:
+                    model.objects.filter(pk=pk).update(**{field: value})
+                for path, payload in manifest_changes:
+                    _atomic_write_json(Path(path), payload)
+        except OSError as exc:
+            raise CommandError(f"Failed to atomically rewrite a workflow manifest: {exc}") from exc
+
+        republished = 0
+        if not options["skip_publish"]:
+            for workflow in published_workflows:
+                publish_workflow(workflow, register_deployment=False)
+                republished += 1
+
+        mode = "rotated" if rotate else "encrypted"
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"Workflow secrets {mode}: {len(database_changes)} database rows, "
+                f"{len(manifest_changes)} manifests; republished {republished} workflows."
+            )
+        )

--- a/backend/workflows/models.py
+++ b/backend/workflows/models.py
@@ -14,6 +14,30 @@ from django.contrib.auth.models import User
 from django.utils import timezone
 
 
+def _secure_action_config(instance, field_name, action_type):
+    """Encrypt sensitive values and preserve omitted write-only values on save."""
+    from .secret_config import prepare_config_for_storage
+
+    existing = {}
+    if instance.pk:
+        existing = (
+            instance.__class__.objects.filter(pk=instance.pk)
+            .values_list(field_name, flat=True)
+            .first()
+            or {}
+        )
+    current = getattr(instance, field_name) or {}
+    secured = prepare_config_for_storage(action_type or "", current, existing=existing)
+    setattr(instance, field_name, secured)
+    return secured != current
+
+
+def _include_secured_field(kwargs, field_name):
+    update_fields = kwargs.get("update_fields")
+    if update_fields is not None and field_name not in update_fields:
+        kwargs["update_fields"] = set(update_fields) | {field_name}
+
+
 class ActionTemplate(models.Model):
     """
     Reusable action templates that can be used in workflow steps.
@@ -68,6 +92,11 @@ class ActionTemplate(models.Model):
 
     def __str__(self):
         return f"{self.name} ({self.action_type})"
+
+    def save(self, *args, **kwargs):
+        if _secure_action_config(self, "default_config", self.action_type):
+            _include_secured_field(kwargs, "default_config")
+        return super().save(*args, **kwargs)
 
 
 class Workflow(models.Model):
@@ -389,6 +418,11 @@ class WorkflowStep(models.Model):
     def __str__(self):
         return f"{self.workflow.name} - Step {self.order}: {self.name}"
 
+    def save(self, *args, **kwargs):
+        if _secure_action_config(self, "action_config", self.action_type):
+            _include_secured_field(kwargs, "action_config")
+        return super().save(*args, **kwargs)
+
 
 class SavedWorkflowNode(models.Model):
     """Reusable node template saved from workflow editor (Save As)."""
@@ -414,6 +448,11 @@ class SavedWorkflowNode(models.Model):
 
     def __str__(self):
         return f"{self.name} ({self.node_category})"
+
+    def save(self, *args, **kwargs):
+        if _secure_action_config(self, "action_config", self.action_type):
+            _include_secured_field(kwargs, "action_config")
+        return super().save(*args, **kwargs)
 
 
 class WorkflowExecution(models.Model):
@@ -632,6 +671,41 @@ class StepExecution(models.Model):
 
     def __str__(self):
         return f"{self.step.name} - {self.status}"
+
+    def save(self, *args, **kwargs):
+        from .secret_config import prepare_config_for_storage
+
+        existing = {}
+        if self.pk:
+            existing = (
+                StepExecution.objects.filter(pk=self.pk)
+                .values_list("input_data", flat=True)
+                .first()
+                or {}
+            )
+        current = self.input_data or {}
+        if isinstance(current.get("action_config"), dict):
+            secured = dict(current)
+            existing_action_config = (
+                existing.get("action_config", {})
+                if isinstance(existing.get("action_config"), dict)
+                else {}
+            )
+            secured["action_config"] = prepare_config_for_storage(
+                self.step.action_type,
+                current["action_config"],
+                existing=existing_action_config,
+            )
+        else:
+            secured = prepare_config_for_storage(
+                self.step.action_type,
+                current,
+                existing=existing,
+            )
+        if secured != current:
+            self.input_data = secured
+            _include_secured_field(kwargs, "input_data")
+        return super().save(*args, **kwargs)
 
     def get_duration_seconds(self):
         """Calculate step duration in seconds."""

--- a/backend/workflows/persistence.py
+++ b/backend/workflows/persistence.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from copy import deepcopy
 from typing import Any, Dict, Iterable, List
+from uuid import uuid4
 
 from django.contrib.auth import get_user_model
 from django.db import transaction
@@ -96,6 +97,29 @@ def build_edges_from_step_payloads(steps: Iterable[Dict[str, Any]]) -> List[Dict
     return edges
 
 
+def remap_step_ids_for_new_workflow(steps: Iterable[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Assign portable node IDs and rewrite all intra-workflow references."""
+    remapped = [deepcopy(step) for step in steps]
+    id_map = {
+        _coerce_step_id(step.get('id')): str(uuid4())
+        for step in remapped
+        if step.get('id')
+    }
+
+    for step in remapped:
+        old_id = _coerce_step_id(step.get('id'))
+        step['id'] = id_map.get(old_id) or str(uuid4())
+        for field in ('next_step_true', 'next_step_false'):
+            old_target = _coerce_step_id(step.get(field))
+            step[field] = id_map.get(old_target) if old_target else None
+        step['connections'] = [
+            id_map[target]
+            for target in map(_coerce_step_id, step.get('connections') or [])
+            if target in id_map
+        ]
+    return remapped
+
+
 @transaction.atomic
 def persist_workflow_definition(
     *,
@@ -108,6 +132,8 @@ def persist_workflow_definition(
     is_draft: bool = False,
     tags: List[str] | None = None,
     update_existing: bool = True,
+    require_sensitive: bool = True,
+    preserve_existing_secrets: bool = True,
 ) -> Workflow:
     from .serializers import WorkflowCreateSerializer
 
@@ -120,6 +146,10 @@ def persist_workflow_definition(
         _normalize_step_payload(step, index)
         for index, step in enumerate(raw_steps)
     ]
+    instance = Workflow.objects.filter(name=name).first() if update_existing else None
+    if instance is None:
+        normalized_steps = remap_step_ids_for_new_workflow(normalized_steps)
+
     payload = {
         'name': name,
         'description': workflow_definition.get('description') or '',
@@ -135,8 +165,14 @@ def persist_workflow_definition(
         'execution_engine': 'prefect',
     }
 
-    instance = Workflow.objects.filter(name=name).first() if update_existing else None
-    serializer = WorkflowCreateSerializer(instance=instance, data=payload)
+    serializer = WorkflowCreateSerializer(
+        instance=instance,
+        data=payload,
+        context={
+            'require_sensitive': require_sensitive,
+            'preserve_existing_secrets': preserve_existing_secrets,
+        },
+    )
     serializer.is_valid(raise_exception=True)
     workflow = serializer.save(created_by=created_by) if instance is None else serializer.save()
 

--- a/backend/workflows/prefect_client.py
+++ b/backend/workflows/prefect_client.py
@@ -178,26 +178,36 @@ def update_deployment_schedule(
     """
     Update the schedule attached to a Prefect deployment.
 
-    Prefect 3.7.x accepts a ``schedule`` object on the deployment. We use this
-    to keep Prefect's scheduler aligned with Django's WorkflowSchedule records.
+    Prefect 3.x represents deployment schedules as a ``schedules`` list. We
+    keep a stable slug so subsequent updates replace the Argus-owned schedule.
     """
     url = f"{_api_base()}/deployments/{deployment_id}"
-    payload: Dict[str, Any] = {
-        'schedule': schedule,
-        'is_schedule_active': bool(is_active),
-    }
+    payload: Dict[str, Any] = {'schedules': []}
+    if schedule is not None:
+        payload['schedules'] = [{
+            'schedule': schedule,
+            'active': bool(is_active),
+            'slug': 'argus-workflow-schedule',
+        }]
     resp = requests.patch(url, json=payload, headers=_headers(), timeout=_timeout())
     if resp.status_code >= 400:
         raise PrefectAPIError(
             f'Prefect update_deployment_schedule returned {resp.status_code}: {resp.text[:500]}'
         )
+    if not resp.text.strip():
+        return {}
     return resp.json()
 
 
 def list_deployments(limit: int = 200) -> list[Dict[str, Any]]:
     """List Prefect deployments for UI sync."""
-    url = f"{_api_base()}/deployments?limit={limit}"
-    resp = requests.get(url, headers=_headers(), timeout=_timeout())
+    url = f"{_api_base()}/deployments/filter"
+    resp = requests.post(
+        url,
+        json={'limit': max(int(limit), 1)},
+        headers=_headers(),
+        timeout=_timeout(),
+    )
     if resp.status_code >= 400:
         raise PrefectAPIError(
             f'Prefect list_deployments returned {resp.status_code}: {resp.text[:500]}'

--- a/backend/workflows/prefect_dispatcher.py
+++ b/backend/workflows/prefect_dispatcher.py
@@ -16,6 +16,10 @@ logger = logging.getLogger(__name__)
 
 
 def _serialize_step(step: WorkflowStep) -> Dict[str, Any]:
+    action_config: Dict[str, Any] = {}
+    if step.action_template and step.action_template.default_config:
+        action_config.update(step.action_template.default_config)
+    action_config.update(step.action_config or {})
     return {
         'id': str(step.id),
         'order': step.order,
@@ -23,7 +27,9 @@ def _serialize_step(step: WorkflowStep) -> Dict[str, Any]:
         'node_type': step.node_type,
         'node_category': step.node_category,
         'action_type': step.action_type,
-        'action_config': step.action_config or {},
+        # This is intentionally ciphertext. Prefect task parameters and
+        # generated manifests must never receive decrypted credentials.
+        'action_config': action_config,
         'timeout_seconds': step.timeout_seconds,
         'on_failure': step.on_failure,
         'retry_count': step.retry_count,

--- a/backend/workflows/publisher.py
+++ b/backend/workflows/publisher.py
@@ -5,6 +5,7 @@ import json
 import logging
 import os
 import tempfile
+from copy import deepcopy
 from datetime import datetime, timezone as dt_timezone
 from pathlib import Path
 from typing import Any, Dict, Iterable, List
@@ -12,6 +13,13 @@ from typing import Any, Dict, Iterable, List
 from .models import Workflow
 from .persistence import persist_workflow_definition
 from .prefect_dispatcher import _serialize_workflow
+from .secret_config import (
+    SecretConfigError,
+    decrypt_sensitive_value,
+    is_encrypted,
+    prepare_config_for_storage,
+    sensitive_fields,
+)
 from .flows.generic_workflow_flow import ACTION_TASKS
 
 logger = logging.getLogger(__name__)
@@ -62,6 +70,32 @@ def _validate_action_types(steps: Iterable[Dict[str, Any]]) -> None:
         raise ValueError(f'Unsupported workflow action types: {joined}')
 
 
+def _validate_action_configs(steps: Iterable[Dict[str, Any]]) -> None:
+    invalid: List[str] = []
+    for step in steps:
+        if step.get('node_type') != 'action':
+            continue
+        action_type = str(step.get('action_type') or '').strip()
+        config = step.get('action_config') or {}
+        try:
+            # Validation only: reuse stored ciphertext without decrypting values
+            # into the manifest or changing the database configuration.
+            prepare_config_for_storage(
+                action_type,
+                {},
+                existing=config,
+                require_sensitive=True,
+            )
+        except SecretConfigError as exc:
+            detail = '; '.join(str(message) for message in exc.messages)
+            invalid.append(f"{step.get('name') or action_type}: {detail}")
+
+    if invalid:
+        raise ValueError(
+            'Workflow action configuration is incomplete: ' + '; '.join(invalid)
+        )
+
+
 def _build_manifest_record(workflow: Workflow, version: int) -> Dict[str, Any]:
     payload = _serialize_workflow(workflow)
     payload['trigger_conditions'] = workflow.trigger_conditions or {}
@@ -106,10 +140,33 @@ def resolve_manifest_metadata(workflow: Workflow) -> Dict[str, Any]:
         return json.load(handle)
 
 
+def load_current_published_manifest(workflow: Workflow) -> tuple[Dict[str, Any], Dict[str, Any]]:
+    """Load and validate the manifest selected by a workflow's current pointer."""
+    pointer = resolve_manifest_metadata(workflow)
+    manifest_filename = str(pointer.get('manifest_filename') or '').strip()
+    try:
+        manifest_version = int(pointer.get('current_version') or 0)
+    except (TypeError, ValueError) as exc:
+        raise ValueError('Published manifest version is invalid.') from exc
+
+    if manifest_version < 1 or not manifest_filename:
+        raise ValueError('Published manifest pointer is incomplete.')
+    if Path(manifest_filename).name != manifest_filename:
+        raise ValueError('Published manifest filename is invalid.')
+
+    manifest = load_manifest_definition(workflow, manifest_version)
+    meta = manifest.get('_meta') or {}
+    if int(meta.get('version') or 0) != manifest_version:
+        raise ValueError('Published manifest version does not match its pointer.')
+    if manifest_filename != _manifest_filename(manifest_version):
+        raise ValueError('Published manifest filename does not match its version.')
+    return pointer, manifest
+
+
 def get_published_state(workflow: Workflow) -> Dict[str, Any]:
     try:
-        pointer = resolve_manifest_metadata(workflow)
-    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        pointer, _ = load_current_published_manifest(workflow)
+    except (FileNotFoundError, json.JSONDecodeError, OSError, TypeError, ValueError):
         return {
             'published_version': None,
             'published_at': None,
@@ -121,6 +178,16 @@ def get_published_state(workflow: Workflow) -> Dict[str, Any]:
         'published_at': pointer.get('published_at'),
         'has_unpublished_changes': bool(workflow.is_draft),
     }
+
+
+def build_published_export(workflow: Workflow) -> tuple[Dict[str, Any], Dict[str, Any]]:
+    """Return the last published manifest, including encrypted secret values."""
+    pointer, manifest = load_current_published_manifest(workflow)
+    exported = deepcopy(manifest)
+    meta = exported.setdefault('_meta', {})
+    meta['export_source'] = 'last_published_manifest'
+    meta['contains_encrypted_sensitive_values'] = True
+    return exported, pointer
 
 
 def _next_publish_version(workflow: Workflow) -> int:
@@ -154,6 +221,7 @@ def publish_workflow(
 ) -> Dict[str, Any]:
     active_steps = _active_steps(workflow)
     _validate_action_types(active_steps)
+    _validate_action_configs(active_steps)
 
     publish_version = _next_publish_version(workflow)
     manifest = _build_manifest_record(workflow, publish_version)
@@ -184,6 +252,9 @@ def publish_workflow(
 
 
 def list_published_manifests() -> List[Dict[str, Any]]:
+    # Intentionally retained but not exposed by URLs/UI. The product does not
+    # currently support disaster recovery from server-local manifests, and
+    # restoring one can mismatch database UUIDs and published-state pointers.
     if not GENERATED_FLOWS_DIR.exists():
         return []
 
@@ -221,6 +292,8 @@ def import_workflow_from_manifest(
     created_by,
     update_existing: bool = True,
 ) -> Workflow:
+    # Intentionally retained as dormant recovery code. See the comment on
+    # list_published_manifests; normal transfers must use uploaded JSON.
     manifest_path = GENERATED_FLOWS_DIR / filename
     if not manifest_path.exists():
         raise FileNotFoundError(f'Manifest file not found: {filename}')
@@ -239,7 +312,46 @@ def import_workflow_from_json_payload(
     *,
     created_by,
     update_existing: bool = True,
+    import_report: Dict[str, Any] | None = None,
 ) -> Workflow:
+    payload = deepcopy(payload)
+    removed_secret_fields: List[Dict[str, Any]] = []
+    for step in payload.get('steps') or []:
+        if not isinstance(step, dict):
+            continue
+        action_type = str(step.get('action_type') or '').strip()
+        config = step.get('action_config')
+        if not isinstance(config, dict):
+            continue
+
+        original_config = deepcopy(config)
+        invalid_fields: List[str] = []
+        for field in sensitive_fields(action_type):
+            value = original_config.get(field)
+            if not is_encrypted(value):
+                continue
+            try:
+                decrypt_sensitive_value(
+                    action_type,
+                    field,
+                    value,
+                    original_config,
+                )
+            except SecretConfigError:
+                invalid_fields.append(field)
+
+        for field in invalid_fields:
+            config.pop(field, None)
+        if invalid_fields:
+            removed_secret_fields.append({
+                'step_name': str(step.get('name') or action_type or 'Unnamed step'),
+                'action_type': action_type,
+                'fields': sorted(invalid_fields),
+            })
+
+    if import_report is not None:
+        import_report['removed_secret_fields'] = removed_secret_fields
+
     meta = payload.get('_meta', {})
     trigger_type = meta.get('trigger_type') or payload.get('trigger_type', 'manual')
     trigger_conditions = meta.get('trigger_conditions') or payload.get('trigger_conditions') or {}
@@ -252,10 +364,12 @@ def import_workflow_from_json_payload(
         trigger_type=trigger_type,
         trigger_conditions=trigger_conditions,
         schedule_cron=schedule_cron,
-        is_active=True,
-        is_draft=False,
+        is_active=False,
+        is_draft=True,
         tags=tags,
         update_existing=update_existing,
+        require_sensitive=False,
+        preserve_existing_secrets=False,
     )
-    logger.info('Imported workflow "%s" (id=%s) from published payload', workflow.name, workflow.id)
+    logger.info('Imported workflow "%s" (id=%s) as an inactive draft', workflow.name, workflow.id)
     return workflow

--- a/backend/workflows/secret_config.py
+++ b/backend/workflows/secret_config.py
@@ -1,0 +1,305 @@
+"""Encryption and redaction helpers for workflow action configuration.
+
+Stored values intentionally remain encrypted. Callers may decrypt only the
+short-lived copy passed directly to an action's ``execute`` method.
+"""
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable
+
+from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured, ValidationError
+
+
+ENCRYPTED_PREFIX = "enc:v1:"
+
+
+class SecretConfigError(ValidationError):
+    """Raised when a sensitive action configuration cannot be handled safely."""
+
+
+@dataclass(frozen=True)
+class SensitiveField:
+    name: str
+    required: bool
+    bindings: tuple[str, ...]
+    rebindable: tuple[str, ...]
+
+
+def _action_schema(action_type: str) -> Dict[str, Any]:
+    # Lazy import avoids loading the action registry while Django models import.
+    from .actions import ActionRegistry
+
+    action_class = ActionRegistry.get_all_actions().get(action_type)
+    return copy.deepcopy(getattr(action_class, "config_schema", {}) or {})
+
+
+def sensitive_fields(action_type: str) -> Dict[str, SensitiveField]:
+    schema = _action_schema(action_type)
+    required = set(schema.get("required") or [])
+    result: Dict[str, SensitiveField] = {}
+    for name, definition in (schema.get("properties") or {}).items():
+        if not isinstance(definition, dict) or not definition.get("x-sensitive"):
+            continue
+        result[name] = SensitiveField(
+            name=name,
+            required=name in required,
+            bindings=tuple(definition.get("x-secret-bindings") or ()),
+            rebindable=tuple(definition.get("x-secret-rebindable") or ()),
+        )
+    return result
+
+
+def is_encrypted(value: Any) -> bool:
+    return isinstance(value, str) and value.startswith(ENCRYPTED_PREFIX)
+
+
+def _fernet_ring():
+    keys = list(getattr(settings, "WORKFLOW_ENCRYPTION_KEYS", None) or [])
+    if not keys:
+        raise ImproperlyConfigured(
+            "WORKFLOW_ENCRYPTION_KEYS is required for sensitive workflow configuration."
+        )
+    try:
+        from cryptography.fernet import Fernet, MultiFernet
+
+        fernets = [Fernet(str(key).encode("ascii")) for key in keys]
+        return fernets[0], MultiFernet(fernets)
+    except (ImportError, TypeError, ValueError) as exc:
+        raise ImproperlyConfigured(
+            "WORKFLOW_ENCRYPTION_KEYS contains an invalid Fernet key or cryptography is unavailable."
+        ) from exc
+
+
+def _normalised_binding_value(field: str, value: Any, schema: Dict[str, Any]) -> Any:
+    if value in (None, ""):
+        value = ((schema.get("properties") or {}).get(field) or {}).get("default")
+    if field == "provider" and value in (None, ""):
+        return "generic"
+    if isinstance(value, str):
+        value = value.strip()
+        if field in {"api_url", "url"}:
+            value = value.rstrip("/")
+    return value
+
+
+def _binding_snapshot(action_type: str, config: Dict[str, Any], spec: SensitiveField) -> Dict[str, Any]:
+    schema = _action_schema(action_type)
+    return {
+        field: _normalised_binding_value(field, config.get(field), schema)
+        for field in spec.bindings
+    }
+
+
+def _binding_digest(action_type: str, field: str, binding: Dict[str, Any]) -> str:
+    canonical = json.dumps(
+        {"action_type": action_type, "field": field, "binding": binding},
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+    ).encode("utf-8")
+    return hashlib.sha256(canonical).hexdigest()
+
+
+def encrypt_sensitive_value(
+    action_type: str,
+    field: str,
+    value: Any,
+    config: Dict[str, Any],
+) -> str:
+    spec = sensitive_fields(action_type).get(field)
+    if spec is None:
+        raise SecretConfigError(f"{field} is not declared as a sensitive field for {action_type}.")
+    primary, _ = _fernet_ring()
+    binding = _binding_snapshot(action_type, config, spec)
+    payload = {
+        "version": 1,
+        "action_type": action_type,
+        "field": field,
+        "binding_digest": _binding_digest(action_type, field, binding),
+        "value": value,
+    }
+    encoded = json.dumps(
+        payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False
+    ).encode("utf-8")
+    return ENCRYPTED_PREFIX + primary.encrypt(encoded).decode("ascii")
+
+
+def decrypt_sensitive_value(
+    action_type: str,
+    field: str,
+    value: Any,
+    config: Dict[str, Any],
+) -> Any:
+    if not is_encrypted(value):
+        raise SecretConfigError(f"Sensitive field {field} is not encrypted.")
+    spec = sensitive_fields(action_type).get(field)
+    if spec is None:
+        raise SecretConfigError(f"{field} is not declared as a sensitive field for {action_type}.")
+    _, ring = _fernet_ring()
+    try:
+        from cryptography.fernet import InvalidToken
+
+        decoded = ring.decrypt(value[len(ENCRYPTED_PREFIX):].encode("ascii"))
+        payload = json.loads(decoded.decode("utf-8"))
+    except (InvalidToken, UnicodeError, ValueError, TypeError, json.JSONDecodeError) as exc:
+        raise SecretConfigError(f"Sensitive field {field} could not be decrypted.") from exc
+
+    binding = _binding_snapshot(action_type, config, spec)
+    expected = _binding_digest(action_type, field, binding)
+    if (
+        payload.get("version") != 1
+        or payload.get("action_type") != action_type
+        or payload.get("field") != field
+        or payload.get("binding_digest") != expected
+    ):
+        raise SecretConfigError(
+            f"Sensitive field {field} is not valid for the current action target; submit it again."
+        )
+    return payload.get("value")
+
+
+def prepare_config_for_storage(
+    action_type: str,
+    incoming: Dict[str, Any] | None,
+    *,
+    existing: Dict[str, Any] | None = None,
+    require_sensitive: bool = False,
+) -> Dict[str, Any]:
+    """Merge write-only values, validate imported tokens, and encrypt plaintext."""
+    incoming = copy.deepcopy(incoming or {})
+    existing = copy.deepcopy(existing or {})
+    merged = copy.deepcopy(existing)
+    merged.update(incoming)
+    specs = sensitive_fields(action_type)
+
+    for field, spec in specs.items():
+        supplied = field in incoming
+        supplied_value = incoming.get(field)
+
+        if (not supplied or supplied_value == "") and field in existing:
+            existing_value = existing[field]
+            if is_encrypted(existing_value):
+                try:
+                    decrypt_sensitive_value(action_type, field, existing_value, merged)
+                    merged[field] = existing_value
+                except SecretConfigError as target_error:
+                    old_binding = _binding_snapshot(action_type, existing, spec)
+                    new_binding = _binding_snapshot(action_type, merged, spec)
+                    changed_bindings = {
+                        name for name in spec.bindings
+                        if old_binding.get(name) != new_binding.get(name)
+                    }
+                    if changed_bindings and changed_bindings.issubset(set(spec.rebindable)):
+                        plaintext = decrypt_sensitive_value(
+                            action_type, field, existing_value, existing
+                        )
+                        merged[field] = encrypt_sensitive_value(
+                            action_type, field, plaintext, merged
+                        )
+                    else:
+                        raise target_error
+            else:
+                # Legacy plaintext encountered through an update path is
+                # upgraded immediately instead of being preserved as plaintext.
+                merged[field] = encrypt_sensitive_value(
+                    action_type, field, existing_value, merged
+                )
+        elif not supplied or supplied_value in (None, ""):
+            merged.pop(field, None)
+        elif is_encrypted(supplied_value):
+            try:
+                # Imported ciphertext must belong to this environment and target.
+                decrypt_sensitive_value(action_type, field, supplied_value, merged)
+                merged[field] = supplied_value
+            except SecretConfigError as target_error:
+                if existing.get(field) != supplied_value:
+                    raise target_error
+                old_binding = _binding_snapshot(action_type, existing, spec)
+                new_binding = _binding_snapshot(action_type, merged, spec)
+                changed_bindings = {
+                    name for name in spec.bindings
+                    if old_binding.get(name) != new_binding.get(name)
+                }
+                if changed_bindings and changed_bindings.issubset(set(spec.rebindable)):
+                    plaintext = decrypt_sensitive_value(
+                        action_type, field, supplied_value, existing
+                    )
+                    merged[field] = encrypt_sensitive_value(
+                        action_type, field, plaintext, merged
+                    )
+                else:
+                    raise target_error
+        else:
+            merged[field] = encrypt_sensitive_value(action_type, field, supplied_value, merged)
+
+        if field in merged and is_encrypted(merged[field]):
+            # Reject preserving credentials when a bound target has changed.
+            decrypt_sensitive_value(action_type, field, merged[field], merged)
+
+        if require_sensitive and spec.required and field not in merged:
+            raise SecretConfigError(f"Sensitive field {field} is required.")
+
+    if require_sensitive and action_type in {"block_ip", "release_ip"}:
+        if str(merged.get("provider") or "generic").lower() == "opnsense":
+            for field in ("api_key", "api_secret"):
+                if field not in merged:
+                    raise SecretConfigError(f"Sensitive field {field} is required for OPNsense.")
+    return merged
+
+
+def decrypt_config_for_execution(action_type: str, config: Dict[str, Any] | None) -> Dict[str, Any]:
+    result = copy.deepcopy(config or {})
+    for field in sensitive_fields(action_type):
+        if field in result:
+            result[field] = decrypt_sensitive_value(action_type, field, result[field], result)
+    return result
+
+
+def rotate_config(action_type: str, config: Dict[str, Any] | None) -> Dict[str, Any]:
+    plaintext = decrypt_config_for_execution(action_type, config or {})
+    result = copy.deepcopy(config or {})
+    for field in sensitive_fields(action_type):
+        if field in plaintext:
+            result[field] = encrypt_sensitive_value(action_type, field, plaintext[field], result)
+    return result
+
+
+def redact_config(action_type: str, config: Dict[str, Any] | None) -> tuple[Dict[str, Any], list[str]]:
+    result = copy.deepcopy(config or {})
+    configured = []
+    for field in sensitive_fields(action_type):
+        if field in result and result[field] not in (None, ""):
+            configured.append(field)
+        result.pop(field, None)
+    return result, sorted(configured)
+
+
+def redact_values(value: Any, secrets: Iterable[Any]) -> Any:
+    """Remove plaintext credential values from result/log structures."""
+    def collect_strings(items):
+        collected = []
+        for item in items:
+            if isinstance(item, str) and item:
+                collected.append(item)
+            elif isinstance(item, dict):
+                collected.extend(collect_strings(item.values()))
+            elif isinstance(item, (list, tuple, set)):
+                collected.extend(collect_strings(item))
+        return collected
+
+    secret_strings = collect_strings(secrets)
+    if isinstance(value, dict):
+        return {key: redact_values(item, secret_strings) for key, item in value.items()}
+    if isinstance(value, list):
+        return [redact_values(item, secret_strings) for item in value]
+    if isinstance(value, tuple):
+        return tuple(redact_values(item, secret_strings) for item in value)
+    if isinstance(value, str):
+        for secret in secret_strings:
+            value = value.replace(secret, "[REDACTED]")
+    return value

--- a/backend/workflows/serializers.py
+++ b/backend/workflows/serializers.py
@@ -4,6 +4,7 @@ Workflow Serializers
 Serializers for the workflow API endpoints.
 """
 from rest_framework import serializers
+from django.db import transaction
 from .models import (
     ActionTemplate,
     Workflow,
@@ -15,6 +16,69 @@ from .models import (
     TicketWorkflowBinding,
 )
 from .publisher import get_published_state
+from .secret_config import (
+    SecretConfigError,
+    prepare_config_for_storage,
+    redact_config,
+)
+
+
+def _secure_config(action_type, incoming, *, existing=None, require_sensitive=False):
+    try:
+        return prepare_config_for_storage(
+            action_type or "",
+            incoming,
+            existing=existing,
+            require_sensitive=require_sensitive,
+        )
+    except SecretConfigError as exc:
+        raise serializers.ValidationError(exc.messages) from exc
+
+
+def _step_existing_config(instance, attrs):
+    existing = {}
+    template = (
+        attrs.get('action_template')
+        if 'action_template' in attrs
+        else getattr(instance, 'action_template', None)
+    )
+    if template and template.default_config:
+        existing.update(template.default_config)
+    if instance and instance.action_config:
+        existing.update(instance.action_config)
+    return existing
+
+
+def _validate_step_timeout(action_type, config, timeout_seconds):
+    if action_type != 'delay':
+        return
+    try:
+        delay_seconds = min(max(int((config or {}).get('seconds', 5)), 1), 3600)
+        timeout_value = int(timeout_seconds or 0)
+    except (TypeError, ValueError) as exc:
+        raise serializers.ValidationError({
+            'timeout_seconds': 'Delay seconds and timeout_seconds must be integers.'
+        }) from exc
+    if timeout_value <= delay_seconds:
+        raise serializers.ValidationError({
+            'timeout_seconds': 'Delay step timeout_seconds must be greater than its seconds value.'
+        })
+
+
+class SensitiveConfigRepresentationMixin:
+    sensitive_config_field = 'action_config'
+
+    def _representation_action_type(self, obj):
+        return getattr(obj, 'action_type', '') or ''
+
+    def to_representation(self, instance):
+        representation = super().to_representation(instance)
+        field_name = self.sensitive_config_field
+        action_type = self._representation_action_type(instance)
+        safe_config, configured = redact_config(action_type, representation.get(field_name) or {})
+        representation[field_name] = safe_config
+        representation['configured_secret_fields'] = configured
+        return representation
 
 
 class WorkflowPublishedStateMixin:
@@ -29,25 +93,38 @@ class WorkflowPublishedStateMixin:
         return cache[key]
 
 
-class ActionTemplateSerializer(serializers.ModelSerializer):
+class ActionTemplateSerializer(SensitiveConfigRepresentationMixin, serializers.ModelSerializer):
     """Serializer for ActionTemplate model."""
+
+    sensitive_config_field = 'default_config'
+    configured_secret_fields = serializers.ListField(child=serializers.CharField(), read_only=True)
 
     class Meta:
         model = ActionTemplate
         fields = [
             'id', 'name', 'category', 'description', 'action_type',
-            'config_schema', 'default_config', 'is_active',
+            'config_schema', 'default_config', 'configured_secret_fields', 'is_active',
             'created_at', 'updated_at'
         ]
         read_only_fields = ['id', 'created_at', 'updated_at']
 
+    def validate(self, attrs):
+        action_type = attrs.get('action_type') or getattr(self.instance, 'action_type', '')
+        if 'default_config' in attrs:
+            existing = getattr(self.instance, 'default_config', {}) if self.instance else {}
+            attrs['default_config'] = _secure_config(
+                action_type, attrs['default_config'], existing=existing
+            )
+        return attrs
 
-class WorkflowStepSerializer(serializers.ModelSerializer):
+
+class WorkflowStepSerializer(SensitiveConfigRepresentationMixin, serializers.ModelSerializer):
     """Serializer for WorkflowStep model."""
     action_template_name = serializers.CharField(
         source='action_template.name',
         read_only=True
     )
+    configured_secret_fields = serializers.ListField(child=serializers.CharField(), read_only=True)
 
     class Meta:
         model = WorkflowStep
@@ -55,15 +132,32 @@ class WorkflowStepSerializer(serializers.ModelSerializer):
             'id', 'workflow', 'order', 'name',
             'node_type', 'node_category', 'position_x', 'position_y',
             'action_template', 'action_template_name', 'action_type',
-            'action_config', 'timeout_seconds', 'on_failure',
+            'action_config', 'configured_secret_fields', 'timeout_seconds', 'on_failure',
             'retry_count', 'retry_delay_seconds', 'condition',
             'next_step_true', 'next_step_false', 'connections',
             'is_active', 'created_at', 'updated_at'
         ]
         read_only_fields = ['id', 'created_at', 'updated_at']
 
+    def validate(self, attrs):
+        action_type = attrs.get('action_type') or getattr(self.instance, 'action_type', '')
+        if 'action_config' in attrs:
+            existing = _step_existing_config(self.instance, attrs)
+            attrs['action_config'] = _secure_config(
+                action_type,
+                attrs['action_config'],
+                existing=existing,
+                require_sensitive=True,
+            )
+        _validate_step_timeout(
+            action_type,
+            attrs.get('action_config') or getattr(self.instance, 'action_config', {}),
+            attrs.get('timeout_seconds', getattr(self.instance, 'timeout_seconds', 300)),
+        )
+        return attrs
 
-class WorkflowStepCreateSerializer(serializers.ModelSerializer):
+
+class WorkflowStepCreateSerializer(SensitiveConfigRepresentationMixin, serializers.ModelSerializer):
     """Serializer for creating/updating WorkflowStep."""
     id = serializers.UUIDField(required=False, allow_null=True)
     next_step_true = serializers.CharField(required=False, allow_null=True, allow_blank=True)
@@ -72,13 +166,14 @@ class WorkflowStepCreateSerializer(serializers.ModelSerializer):
         child=serializers.CharField(allow_blank=True),
         required=False,
     )
+    configured_secret_fields = serializers.ListField(child=serializers.CharField(), read_only=True)
 
     class Meta:
         model = WorkflowStep
         fields = [
             'id', 'order', 'name', 'node_type', 'node_category', 'position_x', 'position_y',
             'action_template', 'action_type',
-            'action_config', 'timeout_seconds', 'on_failure',
+            'action_config', 'configured_secret_fields', 'timeout_seconds', 'on_failure',
             'retry_count', 'retry_delay_seconds', 'condition',
             'next_step_true', 'next_step_false', 'connections', 'is_active'
         ]
@@ -86,6 +181,27 @@ class WorkflowStepCreateSerializer(serializers.ModelSerializer):
         extra_kwargs = {
             'id': {'read_only': False, 'required': False},
         }
+
+    def validate(self, attrs):
+        # Nested workflow writes need the parent serializer to merge secrets by
+        # original Step ID before the existing rows are rebuilt.
+        if self.parent is not None:
+            return attrs
+        action_type = attrs.get('action_type') or getattr(self.instance, 'action_type', '')
+        if 'action_config' in attrs:
+            existing = _step_existing_config(self.instance, attrs)
+            attrs['action_config'] = _secure_config(
+                action_type,
+                attrs['action_config'],
+                existing=existing,
+                require_sensitive=True,
+            )
+        _validate_step_timeout(
+            action_type,
+            attrs.get('action_config') or getattr(self.instance, 'action_config', {}),
+            attrs.get('timeout_seconds', getattr(self.instance, 'timeout_seconds', 300)),
+        )
+        return attrs
 
 
 class WorkflowScheduleSerializer(serializers.ModelSerializer):
@@ -270,9 +386,31 @@ class WorkflowCreateSerializer(serializers.ModelSerializer):
                     sanitized.append(str(parsed))
             step_data['connections'] = sanitized
 
-    def _create_step(self, workflow, step_data, order_offset=0):
+    def _prepare_step_config(self, step_data, existing_config=None):
+        action_type = step_data.get('action_type') or ''
+        base_config = {}
+        action_template = step_data.get('action_template')
+        if action_template and action_template.default_config:
+            base_config.update(action_template.default_config)
+        if self.context.get('preserve_existing_secrets', True):
+            base_config.update(existing_config or {})
+        step_data['action_config'] = _secure_config(
+            action_type,
+            step_data.get('action_config') or {},
+            existing=base_config,
+            require_sensitive=self.context.get('require_sensitive', True),
+        )
+        _validate_step_timeout(
+            action_type,
+            step_data['action_config'],
+            step_data.get('timeout_seconds', 300),
+        )
+        return step_data
+
+    def _create_step(self, workflow, step_data, order_offset=0, existing_config=None):
         step_id = self._to_uuid_or_none(step_data.pop('id', None))
         self._sanitize_step_references(step_data)
+        self._prepare_step_config(step_data, existing_config)
 
         if 'order' in step_data:
             step_data['order'] = step_data['order'] + order_offset
@@ -285,6 +423,7 @@ class WorkflowCreateSerializer(serializers.ModelSerializer):
 
         return step
 
+    @transaction.atomic
     def create(self, validated_data):
         steps_data = validated_data.pop('steps', [])
         workflow = Workflow.objects.create(**validated_data)
@@ -294,34 +433,70 @@ class WorkflowCreateSerializer(serializers.ModelSerializer):
 
         return workflow
 
+    @transaction.atomic
     def update(self, instance, validated_data):
         steps_data = validated_data.pop('steps', None)
+
+        prepared_steps = None
+        if steps_data is not None:
+            existing_steps = {
+                str(step.id): step.action_config or {}
+                for step in instance.steps.all()
+            }
+            prepared_steps = []
+            for raw_step_data in steps_data:
+                step_data = raw_step_data.copy()
+                original_id = self._to_uuid_or_none(step_data.get('id'))
+                self._prepare_step_config(
+                    step_data,
+                    existing_steps.get(str(original_id), {}),
+                )
+                prepared_steps.append(step_data)
 
         for attr, value in validated_data.items():
             setattr(instance, attr, value)
         instance.save()
 
-        if steps_data is not None:
+        if prepared_steps is not None:
             instance.steps.all().delete()
-            for step_data in steps_data:
+            for step_data in prepared_steps:
                 self._create_step(instance, step_data.copy())
 
         return instance
 
 
-class StepExecutionSerializer(serializers.ModelSerializer):
+class StepExecutionSerializer(SensitiveConfigRepresentationMixin, serializers.ModelSerializer):
     """Serializer for StepExecution model."""
     step_name = serializers.CharField(source='step.name', read_only=True)
     step_order = serializers.IntegerField(source='step.order', read_only=True)
     action_type = serializers.CharField(source='step.action_type', read_only=True)
     duration_seconds = serializers.SerializerMethodField()
+    configured_secret_fields = serializers.ListField(child=serializers.CharField(), read_only=True)
+    sensitive_config_field = 'input_data'
+
+    def _representation_action_type(self, obj):
+        return getattr(getattr(obj, 'step', None), 'action_type', '') or ''
+
+    def to_representation(self, instance):
+        representation = super().to_representation(instance)
+        input_data = representation.get('input_data') or {}
+        nested = input_data.get('action_config') if isinstance(input_data, dict) else None
+        if isinstance(nested, dict):
+            safe_nested, nested_configured = redact_config(
+                self._representation_action_type(instance), nested
+            )
+            input_data['action_config'] = safe_nested
+            representation['configured_secret_fields'] = sorted(set(
+                representation.get('configured_secret_fields', []) + nested_configured
+            ))
+        return representation
 
     class Meta:
         model = StepExecution
         fields = [
             'id', 'step', 'step_name', 'step_order', 'action_type',
             'status', 'attempt_number', 'started_at', 'completed_at',
-            'input_data', 'output_data', 'error_message', 'logs',
+            'input_data', 'configured_secret_fields', 'output_data', 'error_message', 'logs',
             'duration_seconds', 'created_at', 'updated_at'
         ]
         read_only_fields = ['id', 'created_at', 'updated_at']
@@ -394,17 +569,35 @@ class WorkflowExecuteSerializer(serializers.Serializer):
     confirm_mass_update = serializers.BooleanField(required=False, default=False)
 
 
-class SavedWorkflowNodeSerializer(serializers.ModelSerializer):
+class SavedWorkflowNodeSerializer(SensitiveConfigRepresentationMixin, serializers.ModelSerializer):
     """Serializer for reusable saved workflow nodes."""
     created_by_username = serializers.CharField(source='created_by.username', read_only=True)
+    configured_secret_fields = serializers.ListField(child=serializers.CharField(), read_only=True)
 
     class Meta:
         model = SavedWorkflowNode
         fields = [
             'id', 'name', 'node_type', 'node_category',
-            'action_type', 'action_config', 'timeout_seconds', 'on_failure',
+            'action_type', 'action_config', 'configured_secret_fields', 'timeout_seconds', 'on_failure',
             'retry_count', 'retry_delay_seconds', 'condition', 'is_active',
             'created_by', 'created_by_username', 'created_at', 'updated_at',
         ]
         read_only_fields = ['id', 'created_by', 'created_by_username', 'created_at', 'updated_at']
+
+    def validate(self, attrs):
+        action_type = attrs.get('action_type') or getattr(self.instance, 'action_type', '')
+        if 'action_config' in attrs:
+            existing = getattr(self.instance, 'action_config', {}) if self.instance else {}
+            attrs['action_config'] = _secure_config(
+                action_type,
+                attrs['action_config'],
+                existing=existing,
+                require_sensitive=True,
+            )
+        _validate_step_timeout(
+            action_type,
+            attrs.get('action_config') or getattr(self.instance, 'action_config', {}),
+            attrs.get('timeout_seconds', getattr(self.instance, 'timeout_seconds', 300)),
+        )
+        return attrs
 

--- a/backend/workflows/tasks/utils.py
+++ b/backend/workflows/tasks/utils.py
@@ -32,8 +32,18 @@ def execute_action(action_type: str, action_config: Dict[str, Any], context: Dic
     """Execute an action via ActionRegistry and return a normalized dict."""
     ensure_django_ready()
     from ..actions import ActionRegistry
+    from ..secret_config import decrypt_config_for_execution, redact_values, sensitive_fields
 
     action = ActionRegistry.get_action(action_type)
-    result = action.execute(action_config or {}, context or {})
-    return normalize_action_result(result)
+    # why here need to decypt twice
+    execution_config = decrypt_config_for_execution(action_type, action_config or {})
+    secrets = [execution_config.get(field) for field in sensitive_fields(action_type)]
+    try:
+        result = action.execute(execution_config, context or {})
+    except Exception as exc:
+        # Prefect persists task exceptions, so never let a credential-bearing
+        # upstream error escape into task state or logs.
+        safe_error = redact_values(str(exc), secrets)
+        raise RuntimeError(safe_error) from None
+    return redact_values(normalize_action_result(result), secrets)
 

--- a/backend/workflows/tests/__init__.py
+++ b/backend/workflows/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the workflows app."""

--- a/backend/workflows/urls.py
+++ b/backend/workflows/urls.py
@@ -15,7 +15,7 @@ from .views import (
     WorkflowExecutionViewSet,
     WorkflowStatsView,
     WorkflowPublishView,
-    WorkflowPublishedListView,
+    # WorkflowPublishedListView,  # Disabled: no server-manifest disaster recovery.
     WorkflowImportView,
     SavedWorkflowNodeViewSet,
     WorkflowScheduleViewSet,
@@ -44,7 +44,9 @@ urlpatterns = [
     path('prefect/deployments/', PrefectDeploymentListView.as_view(), name='prefect-deployments'),
     path('prefect/sync/', PrefectDeploymentSyncView.as_view(), name='prefect-sync'),
     path('workflows/<uuid:pk>/publish/', WorkflowPublishView.as_view(), name='workflow-publish'),
-    path('publish/manifests/', WorkflowPublishedListView.as_view(), name='workflow-published-list'),
+    # Intentionally disabled rather than deleted. Server-manifest recovery can
+    # mismatch manifest and database UUIDs, and disaster recovery is out of scope.
+    # path('publish/manifests/', WorkflowPublishedListView.as_view(), name='workflow-published-list'),
     path('import/', WorkflowImportView.as_view(), name='workflow-import'),
     path('ticket-playbooks/suggest/', TicketCallablePlaybookSuggestView.as_view(), name='ticket-playbook-suggest'),
     path('ticket-playbooks/<uuid:workflow_id>/inputs-schema/', TicketCallablePlaybookSchemaView.as_view(), name='ticket-playbook-inputs-schema'),

--- a/backend/workflows/views.py
+++ b/backend/workflows/views.py
@@ -19,7 +19,7 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from .actions import ActionRegistry
-from .engine import execute_workflow
+from .engine import WorkflowExecutionUnavailable, execute_workflow
 from .models import (
     ActionTemplate,
     SavedWorkflowNode,
@@ -113,7 +113,6 @@ class ActionTemplateViewSet(viewsets.ModelViewSet):
                 'description': preset['description'],
                 'category': preset['category'],
                 'config_schema': meta.get('config_schema', {}),
-                'default_config': {},
                 'is_active': True,
             }
             obj, was_created = ActionTemplate.objects.update_or_create(
@@ -178,14 +177,42 @@ class WorkflowViewSet(viewsets.ModelViewSet):
         workflow = self.get_object()
         serializer = WorkflowExecuteSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
-        execution = execute_workflow(
-            workflow=workflow,
-            trigger_source=serializer.validated_data.get('trigger_source', 'manual'),
-            trigger_data=serializer.validated_data.get('trigger_data', {}),
-            executed_by=request.user if request.user.is_authenticated else None,
-        )
+        try:
+            execution = execute_workflow(
+                workflow=workflow,
+                trigger_source=serializer.validated_data.get('trigger_source', 'manual'),
+                trigger_data=serializer.validated_data.get('trigger_data', {}),
+                executed_by=request.user if request.user.is_authenticated else None,
+            )
+        except WorkflowExecutionUnavailable as exc:
+            return Response({'error': str(exc)}, status=status.HTTP_409_CONFLICT)
         response = WorkflowExecutionDetailSerializer(execution)
         return Response(response.data, status=status.HTTP_201_CREATED)
+
+    @action(detail=True, methods=['get'], url_path='export')
+    def export_published(self, request, pk=None):
+        """Download the last published manifest with secrets kept encrypted."""
+        workflow = self.get_object()
+        from .publisher import build_published_export
+
+        try:
+            payload, pointer = build_published_export(workflow)
+        except FileNotFoundError:
+            return Response(
+                {'error': 'Workflow must be published before it can be exported.'},
+                status=status.HTTP_409_CONFLICT,
+            )
+        except (OSError, ValueError, TypeError, KeyError) as exc:
+            return Response(
+                {'error': f'Published workflow manifest is unavailable or invalid: {exc}'},
+                status=status.HTTP_409_CONFLICT,
+            )
+
+        version = int(pointer.get('current_version') or 0)
+        filename = f'{slugify(workflow.name) or "workflow"}-published-v{version}.json'
+        response = Response(payload, content_type='application/json')
+        response['Content-Disposition'] = f'attachment; filename="{filename}"'
+        return response
 
     @staticmethod
     def _prefect_schedule_payload(schedule: WorkflowSchedule | None) -> Dict[str, Any] | None:
@@ -383,12 +410,15 @@ class WorkflowScheduleViewSet(viewsets.ModelViewSet):
     @action(detail=True, methods=['post'], url_path='execute')
     def execute_plan(self, request, pk=None):
         schedule = self.get_object()
-        execution = execute_workflow(
-            workflow=schedule.workflow,
-            trigger_data=schedule.trigger_data or {},
-            trigger_source=schedule.trigger_source or 'schedule',
-            executed_by=request.user,
-        )
+        try:
+            execution = execute_workflow(
+                workflow=schedule.workflow,
+                trigger_data=schedule.trigger_data or {},
+                trigger_source=schedule.trigger_source or 'schedule',
+                executed_by=request.user,
+            )
+        except WorkflowExecutionUnavailable as exc:
+            return Response({'error': str(exc)}, status=status.HTTP_409_CONFLICT)
         return Response(WorkflowExecutionDetailSerializer(execution).data, status=status.HTTP_201_CREATED)
 
 
@@ -623,6 +653,11 @@ class WorkflowPublishView(APIView):
         from .publisher import publish_workflow
         try:
             result = publish_workflow(workflow, register_deployment=register_deployment)
+        except ValueError as exc:
+            return Response(
+                {'error': str(exc)},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
         except Exception as exc:
             logger.exception('Workflow publish failed for workflow %s', workflow.id)
             return Response(
@@ -639,7 +674,11 @@ class WorkflowPublishView(APIView):
 
 
 class WorkflowPublishedListView(APIView):
-    """List all published workflow manifests available for import."""
+    """Dormant server-manifest recovery endpoint; intentionally not routed."""
+
+    # Kept (rather than deleted) so the previous recovery implementation is
+    # documented in place. It is disabled because this product does not offer
+    # disaster recovery and imported manifest UUIDs can diverge from DB UUIDs.
 
     permission_classes = [permissions.IsAuthenticated]
 
@@ -655,7 +694,10 @@ class WorkflowImportView(APIView):
     permission_classes = [permissions.IsAuthenticated]
 
     def post(self, request):
-        from .publisher import import_workflow_from_manifest, import_workflow_from_json_payload
+        from .publisher import import_workflow_from_json_payload
+        # Server-local manifest recovery is intentionally disabled. Keep the
+        # old import available in source history without exposing it here:
+        # from .publisher import import_workflow_from_manifest
 
         update_existing = str(request.data.get('update_existing', 'true')).lower() == 'true'
 
@@ -670,51 +712,60 @@ class WorkflowImportView(APIView):
                     {'error': f'Invalid JSON file: {exc}'},
                     status=status.HTTP_400_BAD_REQUEST,
                 )
+            import_report = {}
             workflow = import_workflow_from_json_payload(
                 payload,
                 created_by=request.user,
                 update_existing=update_existing,
+                import_report=import_report,
             )
             return Response({
                 'status': 'imported',
                 'source': 'upload',
                 'workflow_id': str(workflow.id),
                 'workflow_name': workflow.name,
+                'removed_secret_fields': import_report.get('removed_secret_fields', []),
             }, status=status.HTTP_201_CREATED)
 
-        filename = request.data.get('filename')
-        if filename:
-            try:
-                workflow = import_workflow_from_manifest(
-                    filename,
-                    created_by=request.user,
-                    update_existing=update_existing,
-                )
-            except FileNotFoundError as exc:
-                return Response({'error': str(exc)}, status=status.HTTP_404_NOT_FOUND)
-            return Response({
-                'status': 'imported',
-                'source': 'manifest',
-                'workflow_id': str(workflow.id),
-                'workflow_name': workflow.name,
-            }, status=status.HTTP_201_CREATED)
+        # Disabled server-manifest recovery path. It is preserved as comments
+        # because recovery is out of scope and the old implementation could
+        # create a DB workflow whose UUID does not match the manifest pointer.
+        # filename = request.data.get('filename')
+        # if filename:
+        #     try:
+        #         workflow = import_workflow_from_manifest(
+        #             filename,
+        #             created_by=request.user,
+        #             update_existing=update_existing,
+        #         )
+        #     except FileNotFoundError as exc:
+        #         return Response({'error': str(exc)}, status=status.HTTP_404_NOT_FOUND)
+        #     return Response({
+        #         'status': 'imported',
+        #         'source': 'manifest',
+        #         'workflow_id': str(workflow.id),
+        #         'workflow_name': workflow.name,
+        #     }, status=status.HTTP_201_CREATED)
 
         workflow_definition = request.data.get('workflow_definition')
         if isinstance(workflow_definition, dict):
+            import_report = {}
             workflow = import_workflow_from_json_payload(
                 workflow_definition,
                 created_by=request.user,
                 update_existing=update_existing,
+                import_report=import_report,
             )
             return Response({
                 'status': 'imported',
                 'source': 'payload',
                 'workflow_id': str(workflow.id),
                 'workflow_name': workflow.name,
+                'removed_secret_fields': import_report.get('removed_secret_fields', []),
             }, status=status.HTTP_201_CREATED)
 
         return Response(
-            {'error': 'Provide one of: file upload, filename, or workflow_definition payload.'},
+            {'error': 'Provide either a JSON file upload or workflow_definition payload.'},
             status=status.HTTP_400_BAD_REQUEST,
         )
 

--- a/env.example
+++ b/env.example
@@ -1,6 +1,9 @@
 # Django Core Configuration
 SECRET_KEY=replace-with-a-generated-50-plus-character-random-secret
 DEBUG=False
+# Workflow secret encryption key ring, comma-separated; first key encrypts new values.
+# python.exe -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
+WORKFLOW_ENCRYPTION_KEYS=
 ALLOWED_HOSTS=localhost,127.0.0.1,siem.seclink.info,backend
 
 # PostgreSQL Database Configuration

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1041,6 +1041,7 @@ export interface WorkflowStep {
   position_y?: number;
   action_type: string;
   action_config: Record<string, any>;
+  configured_secret_fields?: string[];
   timeout_seconds: number;
   on_failure: 'stop' | 'continue' | 'retry' | 'skip';
   retry_count: number;
@@ -1183,6 +1184,7 @@ export interface SavedWorkflowNode {
   node_category: string;
   action_type?: string;
   action_config: Record<string, any>;
+  configured_secret_fields?: string[];
   timeout_seconds: number;
   on_failure: 'stop' | 'continue' | 'retry' | 'skip';
   retry_count: number;
@@ -1407,7 +1409,25 @@ export async function publishWorkflow(id: string, options?: { register_deploymen
   return r.data;
 }
 
-// List published workflow manifests available for import
+// Export the last published manifest; sensitive values remain encrypted.
+export async function exportWorkflow(id: string): Promise<{ blob: Blob; filename: string }> {
+  const r = await client.get(`${WORKFLOWS_BASE}/workflows/${id}/export/`, {
+    responseType: 'blob',
+  });
+  return {
+    blob: r.data as Blob,
+    filename: extractDownloadFilename(
+      r.headers['content-disposition'],
+      `workflow-${id}-published.json`,
+    ),
+  };
+}
+
+/*
+ * Intentionally disabled rather than deleted. Importing server-local manifests
+ * was a disaster-recovery path, but recovery is out of scope and restored DB
+ * UUIDs can diverge from manifest pointer UUIDs. Normal transfers use JSON files.
+ *
 export async function listPublishedManifests(): Promise<{ manifests: Array<{
   filename: string;
   slug: string;
@@ -1434,6 +1454,7 @@ export async function importWorkflowFromManifest(filename: string): Promise<{
   const r = await client.post(`${WORKFLOWS_BASE}/import/`, { filename });
   return r.data;
 }
+*/
 
 // Import workflow from uploaded JSON file
 export async function importWorkflowFromFile(file: File): Promise<{
@@ -1441,6 +1462,11 @@ export async function importWorkflowFromFile(file: File): Promise<{
   source: string;
   workflow_id: string;
   workflow_name: string;
+  removed_secret_fields?: Array<{
+    step_name: string;
+    action_type: string;
+    fields: string[];
+  }>;
 }> {
   const form = new FormData();
   form.append('file', file);

--- a/frontend/src/modules/workflows/WorkflowEditor.tsx
+++ b/frontend/src/modules/workflows/WorkflowEditor.tsx
@@ -90,7 +90,14 @@ const getApiErrorMessage = (err: any, fallback: string): string => {
   if (typeof data === 'string') return data;
   if (typeof data?.detail === 'string') return data.detail;
   if (typeof data?.error === 'string') return data.error;
-  return fallback;
+  const messages: string[] = [];
+  const collect = (value: any) => {
+    if (typeof value === 'string') messages.push(value);
+    else if (Array.isArray(value)) value.forEach(collect);
+    else if (value && typeof value === 'object') Object.values(value).forEach(collect);
+  };
+  collect(data);
+  return messages[0] || fallback;
 };
 
 const WorkflowEditor: React.FC<WorkflowEditorProps> = ({ workflowId, onBack, onSaved }) => {
@@ -372,13 +379,28 @@ const WorkflowEditor: React.FC<WorkflowEditorProps> = ({ workflowId, onBack, onS
           </Col>
           <Col>
             <Space>
-              {!isNew && workflow?.is_active && (
-                <Button
-                  icon={<PlayCircleOutlined />}
-                  onClick={handleExecute}
+              {!isNew && (
+                <Tooltip
+                  title={
+                    !workflow?.is_active
+                      ? 'Activate this workflow before execution'
+                      : !workflow?.published_version
+                        ? 'Publish this workflow before execution'
+                        : workflow.has_unpublished_changes
+                          ? `Execute the last published version (v${workflow.published_version})`
+                          : `Execute published version v${workflow.published_version}`
+                  }
                 >
-                  Execute
-                </Button>
+                  <span>
+                    <Button
+                      icon={<PlayCircleOutlined />}
+                      onClick={handleExecute}
+                      disabled={!workflow?.is_active || !workflow?.published_version}
+                    >
+                      Execute
+                    </Button>
+                  </span>
+                </Tooltip>
               )}
               <Button
                 icon={<SaveOutlined />}
@@ -676,7 +698,7 @@ const WorkflowEditor: React.FC<WorkflowEditorProps> = ({ workflowId, onBack, onS
               <Row gutter={16}>
                 <Col span={8}>
                   <Form.Item name="timeout_seconds" label="Timeout (seconds)">
-                    <InputNumber min={1} max={3600} style={{ width: '100%' }} />
+                    <InputNumber min={1} max={3601} style={{ width: '100%' }} />
                   </Form.Item>
                 </Col>
                 <Col span={8}>

--- a/frontend/src/modules/workflows/Workflows.tsx
+++ b/frontend/src/modules/workflows/Workflows.tsx
@@ -29,6 +29,7 @@ import {
   HistoryOutlined,
   CloudUploadOutlined,
   ImportOutlined,
+  DownloadOutlined,
 } from '@ant-design/icons';
 import type { ColumnsType } from 'antd/es/table';
 import {
@@ -39,8 +40,11 @@ import {
   getWorkflowStats,
   publishWorkflow,
   cancelWorkflowExecution,
-  listPublishedManifests,
-  importWorkflowFromManifest,
+  exportWorkflow,
+  // Server-manifest recovery is intentionally disabled; see the commented
+  // handler and toolbar button below for the retained rationale/source.
+  // listPublishedManifests,
+  // importWorkflowFromManifest,
   importWorkflowFromFile,
   listTicketWorkflowBindings,
   Workflow,
@@ -72,11 +76,11 @@ const statusColors: Record<string, string> = {
 
 // Compute the run-status main label/color for the merged Status column.
 // Rules:
-//   manual    : draft -> gray 'Manual Run'; active -> blue 'Manual Run';
+//   manual    : unpublished -> gray 'Manual Run'; active -> blue 'Manual Run';
 //               inactive -> gray 'Manual Run · Inactive'
-//   scheduled : draft -> gray 'Schedule Disabled'; active -> green 'Scheduled · Enabled';
+//   scheduled : unpublished -> gray 'Schedule Disabled'; active -> green 'Scheduled · Enabled';
 //               inactive -> red 'Scheduled · Disabled'; cron shown as hint when present
-//   event     : draft -> gray 'Event Trigger'; active -> green 'Listening · Enabled';
+//   event     : unpublished -> gray 'Event Trigger'; active -> green 'Listening · Enabled';
 //               inactive -> red 'Listening · Disabled'
 interface RunStatusInfo {
   color: string;
@@ -85,23 +89,24 @@ interface RunStatusInfo {
 }
 
 const getRunStatusInfo = (workflow: Workflow): RunStatusInfo => {
-  const { trigger_type, is_active, is_draft, schedule_cron } = workflow;
+  const { trigger_type, is_active, published_version, schedule_cron } = workflow;
+  const isPublished = Boolean(published_version);
 
   if (trigger_type === 'manual') {
-    if (is_draft) return { color: 'default', label: 'Manual Run' };
+    if (!isPublished) return { color: 'default', label: 'Manual Run' };
     if (is_active) return { color: 'blue', label: 'Manual Run' };
     return { color: 'default', label: 'Manual Run · Inactive' };
   }
 
   if (trigger_type === 'scheduled') {
     const hint = schedule_cron || undefined;
-    if (is_draft) return { color: 'default', label: 'Schedule Disabled', hint };
+    if (!isPublished) return { color: 'default', label: 'Schedule Disabled', hint };
     if (is_active) return { color: 'green', label: 'Scheduled · Enabled', hint };
     return { color: 'red', label: 'Scheduled · Disabled', hint };
   }
 
   // alert / ticket_created / ticket_status / webhook -> event-driven
-  if (is_draft) return { color: 'default', label: 'Event Trigger' };
+  if (!isPublished) return { color: 'default', label: 'Event Trigger' };
   if (is_active) return { color: 'green', label: 'Listening · Enabled' };
   return { color: 'red', label: 'Listening · Disabled' };
 };
@@ -122,6 +127,7 @@ const Workflows: React.FC<WorkflowsProps> = ({ onNavigate, onVisualEditWorkflow 
   const [modal, modalContextHolder] = Modal.useModal();
   const [workflows, setWorkflows] = useState<Workflow[]>([]);
   const [loading, setLoading] = useState(false);
+  const [exportingWorkflowId, setExportingWorkflowId] = useState<string | null>(null);
   const [stats, setStats] = useState<WorkflowStats | null>(null);
   const [search, setSearch] = useState('');
   const [statusFilter, setStatusFilter] = useState<string>('');
@@ -273,6 +279,27 @@ const Workflows: React.FC<WorkflowsProps> = ({ onNavigate, onVisualEditWorkflow 
     }
   };
 
+  const handleExport = async (workflow: Workflow) => {
+    setExportingWorkflowId(workflow.id);
+    try {
+      const { blob, filename } = await exportWorkflow(workflow.id);
+      const objectUrl = window.URL.createObjectURL(blob);
+      const anchor = document.createElement('a');
+      anchor.href = objectUrl;
+      anchor.download = filename;
+      document.body.appendChild(anchor);
+      anchor.click();
+      anchor.remove();
+      window.URL.revokeObjectURL(objectUrl);
+      message.success(`Published workflow "${workflow.name}" exported`);
+    } catch (err: any) {
+      const detail = err?.response?.data?.error || 'Failed to export published workflow';
+      message.error(detail);
+    } finally {
+      setExportingWorkflowId(null);
+    }
+  };
+
   // Import workflow from uploaded JSON file
   const handleImport = async () => {
     const input = document.createElement('input');
@@ -283,7 +310,16 @@ const Workflows: React.FC<WorkflowsProps> = ({ onNavigate, onVisualEditWorkflow 
       if (!file) return;
       try {
         const result = await importWorkflowFromFile(file);
-        message.success(`Workflow "${result.workflow_name}" imported successfully`);
+        message.success(`Workflow "${result.workflow_name}" imported as an inactive draft; review it before publishing`);
+        const removedSecrets = Array.isArray(result.removed_secret_fields)
+          ? result.removed_secret_fields
+          : [];
+        if (removedSecrets.length > 0) {
+          const details = removedSecrets
+            .map((item) => `${item.step_name}: ${item.fields.join(', ')}`)
+            .join('; ');
+          message.warning(`Some encrypted credentials could not be validated and were removed. Re-enter them before publishing. ${details}`);
+        }
         fetchWorkflows();
         fetchStats();
       } catch (err: any) {
@@ -294,7 +330,12 @@ const Workflows: React.FC<WorkflowsProps> = ({ onNavigate, onVisualEditWorkflow 
     input.click();
   };
 
-  // Import workflow from a published manifest already stored on the server
+  /*
+   * Intentionally disabled rather than deleted. This was a server-manifest
+   * disaster-recovery path. Recovery is out of scope, and recreating a DB row
+   * can assign a UUID that no longer matches the server manifest pointer.
+   * Portable workflow transfer now uses Export JSON / Import JSON.
+   *
   const handleImportPublished = async () => {
     try {
       const result = await listPublishedManifests();
@@ -347,6 +388,7 @@ const Workflows: React.FC<WorkflowsProps> = ({ onNavigate, onVisualEditWorkflow 
       message.error(detail);
     }
   };
+  */
 
   const columns: ColumnsType<Workflow> = [
     {
@@ -468,9 +510,18 @@ const Workflows: React.FC<WorkflowsProps> = ({ onNavigate, onVisualEditWorkflow 
     {
       title: 'Actions',
       key: 'actions',
-      width: 180,
+      width: 230,
       render: (_: any, record: Workflow) => {
         const running = isWorkflowRunning(record);
+        const hasPublishedManifest = Boolean(record.published_version);
+        const canExecute = record.is_active && hasPublishedManifest;
+        const executeTooltip = !record.is_active
+          ? 'Activate this workflow before execution'
+          : !hasPublishedManifest
+            ? 'Publish this workflow before execution'
+            : record.has_unpublished_changes
+              ? `Execute the last published version (v${record.published_version})`
+              : `Execute published version v${record.published_version}`;
         return (
           <Space size="small" wrap>
             {running ? (
@@ -485,16 +536,17 @@ const Workflows: React.FC<WorkflowsProps> = ({ onNavigate, onVisualEditWorkflow 
                 />
               </Tooltip>
             ) : (
-              record.is_active && !record.is_draft && (
-                <Tooltip title="Execute">
+              <Tooltip title={executeTooltip}>
+                <span>
                   <Button
                     type="primary"
                     size="small"
                     icon={<PlayCircleOutlined />}
                     onClick={() => handleExecute(record.id)}
+                    disabled={!canExecute}
                   />
-                </Tooltip>
-              )
+                </span>
+              </Tooltip>
             )}
             <Tooltip title="Visual Editor">
               <Button
@@ -509,6 +561,17 @@ const Workflows: React.FC<WorkflowsProps> = ({ onNavigate, onVisualEditWorkflow 
                 icon={<CopyOutlined />}
                 onClick={() => handleClone(record.id)}
               />
+            </Tooltip>
+            <Tooltip title={hasPublishedManifest ? `Export published v${record.published_version} as JSON` : 'Publish this workflow before exporting'}>
+              <span>
+                <Button
+                  size="small"
+                  icon={<DownloadOutlined />}
+                  onClick={() => handleExport(record)}
+                  disabled={!hasPublishedManifest}
+                  loading={exportingWorkflowId === record.id}
+                />
+              </span>
             </Tooltip>
             <Tooltip
               title={
@@ -636,14 +699,19 @@ const Workflows: React.FC<WorkflowsProps> = ({ onNavigate, onVisualEditWorkflow 
                 icon={<ImportOutlined />}
                 onClick={handleImport}
               >
-                Import Workflow
+                Import JSON
               </Button>
+              {/*
+                Intentionally disabled rather than deleted. Import Published was
+                a server-local disaster-recovery path; recovery is out of scope,
+                and restored database UUIDs may not match manifest pointers.
               <Button
                 icon={<CloudUploadOutlined />}
                 onClick={handleImportPublished}
               >
                 Import Published
               </Button>
+              */}
               <Button
                 icon={<HistoryOutlined />}
                 onClick={() => onNavigate?.('/settings/workflows/executions')}

--- a/frontend/src/modules/workflows/components/ActionConfigBuilder.tsx
+++ b/frontend/src/modules/workflows/components/ActionConfigBuilder.tsx
@@ -13,7 +13,7 @@
  *   Integration   : create_ticket, update_ticket
  *   Utility       : log, delay
  */
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import {
   Form,
   Input,
@@ -43,6 +43,8 @@ const { Text } = Typography;
 interface ActionConfigBuilderProps {
   actionType: string;
   config: Record<string, any>;
+  configKey?: string;
+  configuredSecretFields?: string[];
   onChange: (config: Record<string, any>) => void;
 }
 
@@ -59,6 +61,8 @@ type FieldDef = {
   options?: Array<{ value: string; label: string }>;
   default?: any;
   description?: string;
+  sensitive?: boolean;
+  providers?: string[];
 };
 
 type SchemaDef = { name: string; description: string; fields: FieldDef[] };
@@ -91,7 +95,7 @@ const actionSchemas: Record<string, SchemaDef> = {
     fields: [
       {
         name: 'seconds', label: 'Seconds', type: 'number', required: true,
-        default: 5, description: 'Wait time (1–3600 seconds)',
+        default: 5, description: 'Wait time (1–3600 seconds); node timeout must be greater',
       },
     ],
   },
@@ -138,6 +142,7 @@ const actionSchemas: Record<string, SchemaDef> = {
       {
         name: 'headers', label: 'Headers', type: 'keyvalue',
         description: 'Optional HTTP headers sent with the request',
+        sensitive: true,
       },
       {
         name: 'body_template', label: 'Request Body (JSON)', type: 'textarea',
@@ -211,6 +216,14 @@ const actionSchemas: Record<string, SchemaDef> = {
     description: 'Block an IP address via a security-device API (firewall / EDR)',
     fields: [
       {
+        name: 'provider', label: 'Provider', type: 'select', required: true,
+        options: [
+          { value: 'generic', label: 'Generic API' },
+          { value: 'opnsense', label: 'OPNsense' },
+        ],
+        default: 'generic',
+      },
+      {
         name: 'ip_address', label: 'IP Address', type: 'string', required: true,
         placeholder: '{{trigger_data.source_ip}}',
         description: 'Supports dynamic values extracted from the triggering case or alert',
@@ -222,10 +235,27 @@ const actionSchemas: Record<string, SchemaDef> = {
       {
         name: 'api_key', label: 'API Key', type: 'password', required: true,
         placeholder: 'Your API key / token',
+        sensitive: true,
+      },
+      {
+        name: 'api_secret', label: 'API Secret', type: 'password', required: true,
+        placeholder: 'Your OPNsense API secret', sensitive: true, providers: ['opnsense'],
+      },
+      {
+        name: 'alias_name', label: 'Alias Name', type: 'string', required: true,
+        default: 'ARGUS_BLOCKLIST', providers: ['opnsense'],
+      },
+      {
+        name: 'verify_tls', label: 'Verify TLS Certificate', type: 'boolean',
+        default: true, providers: ['opnsense'],
+      },
+      {
+        name: 'kill_states', label: 'Kill Active States', type: 'boolean',
+        default: false, providers: ['opnsense'],
       },
       {
         name: 'duration_hours', label: 'Block Duration (hours)', type: 'number',
-        default: 24, description: '0 = permanent block',
+        default: 24, description: '0 = permanent block', providers: ['generic'],
       },
       {
         name: 'reason', label: 'Reason', type: 'string',
@@ -265,6 +295,14 @@ const actionSchemas: Record<string, SchemaDef> = {
     description: 'Release (unblock) an IP address via a security-device API',
     fields: [
       {
+        name: 'provider', label: 'Provider', type: 'select', required: true,
+        options: [
+          { value: 'generic', label: 'Generic API' },
+          { value: 'opnsense', label: 'OPNsense' },
+        ],
+        default: 'generic',
+      },
+      {
         name: 'ip_address', label: 'IP Address', type: 'string', required: true,
         placeholder: '{{trigger_data.source_ip}}',
         description: 'Supports dynamic values extracted from the triggering case or alert',
@@ -276,6 +314,19 @@ const actionSchemas: Record<string, SchemaDef> = {
       {
         name: 'api_key', label: 'API Key', type: 'password', required: true,
         placeholder: 'Your API key / token',
+        sensitive: true,
+      },
+      {
+        name: 'api_secret', label: 'API Secret', type: 'password', required: true,
+        placeholder: 'Your OPNsense API secret', sensitive: true, providers: ['opnsense'],
+      },
+      {
+        name: 'alias_name', label: 'Alias Name', type: 'string', required: true,
+        default: 'ARGUS_BLOCKLIST', providers: ['opnsense'],
+      },
+      {
+        name: 'verify_tls', label: 'Verify TLS Certificate', type: 'boolean',
+        default: true, providers: ['opnsense'],
       },
       {
         name: 'reason', label: 'Reason', type: 'string',
@@ -583,24 +634,99 @@ const KeyValueInput: React.FC<{
 const ActionConfigBuilder: React.FC<ActionConfigBuilderProps> = ({
   actionType,
   config,
+  configKey,
+  configuredSecretFields = [],
   onChange,
 }) => {
   const [mode, setMode] = useState<'form' | 'json'>('form');
   const [jsonValue, setJsonValue] = useState('');
   const [jsonError, setJsonError] = useState<string | null>(null);
+  const [protectedTargetChanged, setProtectedTargetChanged] = useState(false);
+  const [aliasChanged, setAliasChanged] = useState(false);
   const [form] = Form.useForm();
+  const loadedConfigKey = useRef<string | null>(null);
+  const initialTargets = useRef<Record<string, any>>({});
+  const provider = Form.useWatch('provider', form) || config?.provider || 'generic';
 
   const schema = actionSchemas[actionType];
+  const configuredSecretSet = new Set(configuredSecretFields);
+  const targetCredentialFields = actionType === 'send_webhook'
+    ? ['headers']
+    : actionType === 'block_ip' || actionType === 'release_ip'
+      ? ['api_key', 'api_secret']
+      : ['api_key'];
+  const isConfiguredForCurrentTarget = (fieldName: string) => (
+    configuredSecretSet.has(fieldName)
+    && !(protectedTargetChanged && targetCredentialFields.includes(fieldName))
+  );
+
+  const normalizeTargetValue = (value: any) => String(value || '').trim().replace(/\/+$/, '');
 
   useEffect(() => {
+    const nextConfigKey = `${actionType}:${configKey || ''}`;
+    if (loadedConfigKey.current === nextConfigKey) return;
+    loadedConfigKey.current = nextConfigKey;
+    initialTargets.current = {
+      provider: String(config?.provider || 'generic').toLowerCase(),
+      api_url: normalizeTargetValue(config?.api_url),
+      url: normalizeTargetValue(config?.url),
+      alias_name: String(config?.alias_name || 'ARGUS_BLOCKLIST').trim(),
+    };
+    setProtectedTargetChanged(false);
+    setAliasChanged(false);
     if (config) {
-      form.setFieldsValue(config);
-      setJsonValue(JSON.stringify(config, null, 2));
+      const safeConfig = Object.fromEntries(
+        Object.entries(config).filter(([name, value]) => (
+          !configuredSecretFields.includes(name)
+          && !(typeof value === 'string' && value.startsWith('enc:v1:'))
+        ))
+      );
+      form.resetFields();
+      form.setFieldsValue(safeConfig);
+      setJsonValue(JSON.stringify(safeConfig, null, 2));
     }
-  }, [config, form]);
+  }, [actionType, config, configKey, configuredSecretFields, form]);
+
+  const applyTargetProtection = (inputValues: Record<string, any>) => {
+    const values = { ...inputValues };
+    const initial = initialTargets.current;
+    const apiUrlChanged = normalizeTargetValue(values.api_url) !== initial.api_url;
+    const webhookUrlChanged = normalizeTargetValue(values.url) !== initial.url;
+    const providerChanged = (
+      String(values.provider || 'generic').toLowerCase() !== initial.provider
+    );
+    const isOPNsenseAction = actionType === 'block_ip' || actionType === 'release_ip';
+    const protectedChanged = configuredSecretFields.length > 0 && (
+      actionType === 'send_webhook'
+        ? webhookUrlChanged
+        : apiUrlChanged || (isOPNsenseAction && providerChanged)
+    );
+    const nextAliasChanged = (
+      isOPNsenseAction
+      && configuredSecretFields.some((field) => field === 'api_key' || field === 'api_secret')
+      && String(values.alias_name || 'ARGUS_BLOCKLIST').trim() !== initial.alias_name
+    );
+    setProtectedTargetChanged(protectedChanged);
+    setAliasChanged(nextAliasChanged);
+
+    if (actionType === 'send_webhook' && protectedChanged && !values.headers) {
+      // Headers are optional. A URL change clears them explicitly unless the
+      // user supplies a replacement, so they can never leak to a new target.
+      values.headers = null;
+    }
+    if (
+      isOPNsenseAction
+      && values.provider === 'generic'
+    ) {
+      // OPNsense's optional secret must be explicitly cleared when switching
+      // providers; the API key remains required and must be entered again.
+      values.api_secret = null;
+    }
+    return values;
+  };
 
   const handleFormChange = () => {
-    const values = form.getFieldsValue();
+    const values = applyTargetProtection(form.getFieldsValue(true));
     onChange(values);
     setJsonValue(JSON.stringify(values, null, 2));
   };
@@ -609,9 +735,16 @@ const ActionConfigBuilder: React.FC<ActionConfigBuilderProps> = ({
     setJsonValue(value);
     try {
       const parsed = JSON.parse(value);
+      if (Object.values(parsed).some((item) => (
+        typeof item === 'string' && item.startsWith('enc:v1:')
+      ))) {
+        setJsonError('Encrypted values cannot be viewed or edited here');
+        return;
+      }
+      const protectedValues = applyTargetProtection(parsed);
       setJsonError(null);
-      onChange(parsed);
-      form.setFieldsValue(parsed);
+      onChange(protectedValues);
+      form.setFieldsValue(protectedValues);
     } catch {
       setJsonError('Invalid JSON format');
     }
@@ -622,7 +755,16 @@ const ActionConfigBuilder: React.FC<ActionConfigBuilderProps> = ({
       case 'string':
         return <Input placeholder={field.placeholder} />;
       case 'password':
-        return <Input.Password placeholder={field.placeholder} />;
+        return (
+          <Input.Password
+            autoComplete="new-password"
+            placeholder={
+              isConfiguredForCurrentTarget(field.name)
+                ? 'Configured — leave blank to keep it'
+                : field.placeholder
+            }
+          />
+        );
       case 'number':
         return <InputNumber style={{ width: '100%' }} min={0} />;
       case 'boolean':
@@ -687,7 +829,33 @@ const ActionConfigBuilder: React.FC<ActionConfigBuilderProps> = ({
             <Text type="secondary" style={{ fontSize: 12 }}>{schema.description}</Text>
           </Card>
 
-          {schema.fields.map((field) => (
+          {protectedTargetChanged && (
+            <Alert
+              type="warning"
+              showIcon
+              style={{ marginBottom: 16 }}
+              message="Credential re-entry required"
+              description={
+                actionType === 'send_webhook'
+                  ? 'The webhook URL changed. Existing headers will not be reused; enter replacement headers or leave them empty to clear them.'
+                  : 'The Provider or API URL changed. Re-enter the API Key and, for OPNsense, the API Secret before saving.'
+              }
+            />
+          )}
+
+          {aliasChanged && !protectedTargetChanged && (
+            <Alert
+              type="info"
+              showIcon
+              style={{ marginBottom: 16 }}
+              message="Existing OPNsense credentials will be reused"
+              description="Only the Alias Name changed. The saved API Key and API Secret will be securely rebound to the new alias."
+            />
+          )}
+
+          {schema.fields
+            .filter((field) => !field.providers || field.providers.includes(provider))
+            .map((field) => (
             <Form.Item
               key={field.name}
               name={field.name}
@@ -695,6 +863,9 @@ const ActionConfigBuilder: React.FC<ActionConfigBuilderProps> = ({
                 <Space>
                   {field.label}
                   {field.required && <Text type="danger">*</Text>}
+                  {isConfiguredForCurrentTarget(field.name) && (
+                    <Tag color="green">Configured</Tag>
+                  )}
                   {field.description && (
                     <Tooltip title={field.description}>
                       <InfoCircleOutlined style={{ color: '#999' }} />
@@ -703,12 +874,17 @@ const ActionConfigBuilder: React.FC<ActionConfigBuilderProps> = ({
                 </Space>
               }
               rules={
-                field.required
+                field.required && !isConfiguredForCurrentTarget(field.name)
                   ? [{ required: true, message: `${field.label} is required` }]
                   : []
               }
               valuePropName={field.type === 'boolean' ? 'checked' : 'value'}
               initialValue={field.default}
+              help={
+                isConfiguredForCurrentTarget(field.name)
+                  ? 'Already configured. Leave empty to keep the existing value.'
+                  : undefined
+              }
             >
               {renderField(field)}
             </Form.Item>

--- a/frontend/src/modules/workflows/components/ActionConfigBuilder.tsx
+++ b/frontend/src/modules/workflows/components/ActionConfigBuilder.tsx
@@ -1,543 +1,176 @@
 /**
- * Action Config Builder Component
+ * Visual editor for workflow action configuration.
  *
- * Provides a visual form-based configuration for workflow actions,
- * with the option to switch to raw JSON editing mode.
- *
- * Supported action types:
- *   Control Flow  : (handled as node types – no config builder needed)
- *   Enrichment    : ip_lookup, hash_lookup
- *   Containment   : block_ip, disable_user
- *   Release       : release_ip, enable_user
- *   Notification  : send_email, send_webhook
- *   Integration   : create_ticket, update_ticket
- *   Utility       : log, delay
+ * Field definitions come from the backend Action Registry through the
+ * available-actions API. This component only maps JSON Schema primitives to
+ * Ant Design controls and keeps the existing credential-protection behaviour.
  */
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import {
+  Alert,
+  Button,
+  Card,
+  Divider,
   Form,
   Input,
-  Select,
-  Switch,
   InputNumber,
-  Button,
+  Select,
   Space,
+  Switch,
   Tabs,
-  Card,
   Tag,
-  Divider,
-  Typography,
   Tooltip,
-  Alert,
+  Typography,
 } from 'antd';
 import {
   CodeOutlined,
   FormOutlined,
-  PlusOutlined,
   InfoCircleOutlined,
+  PlusOutlined,
 } from '@ant-design/icons';
+import type { ActionInfo } from 'services/workflows';
 
 const { TextArea } = Input;
 const { Text } = Typography;
 
+type JsonSchemaProperty = {
+  type?: string | string[];
+  title?: string;
+  description?: string;
+  enum?: unknown[];
+  default?: unknown;
+  minimum?: number;
+  maximum?: number;
+  writeOnly?: boolean;
+  items?: JsonSchemaProperty;
+  properties?: Record<string, JsonSchemaProperty>;
+  'x-sensitive'?: boolean;
+};
+
+type ActionConfigSchema = {
+  type?: string;
+  properties?: Record<string, JsonSchemaProperty>;
+  required?: string[];
+};
+
+type FieldDef = {
+  name: string;
+  label: string;
+  type: 'string' | 'number' | 'boolean' | 'select' | 'textarea' | 'array' | 'password' | 'keyvalue';
+  required: boolean;
+  options?: Array<{ value: string | number; label: string }>;
+  default?: unknown;
+  description?: string;
+  sensitive: boolean;
+  minimum?: number;
+  maximum?: number;
+};
+
 interface ActionConfigBuilderProps {
   actionType: string;
+  actionInfo?: ActionInfo;
   config: Record<string, any>;
   configKey?: string;
   configuredSecretFields?: string[];
   onChange: (config: Record<string, any>) => void;
 }
 
-// ── Schema definitions ────────────────────────────────────────────────────
-// Each entry describes what visual fields the form should render.
-// Fields not listed here are still editable in JSON mode.
-
-type FieldDef = {
-  name: string;
-  label: string;
-  type: 'string' | 'number' | 'boolean' | 'select' | 'textarea' | 'array' | 'password' | 'keyvalue';
-  required?: boolean;
-  placeholder?: string;
-  options?: Array<{ value: string; label: string }>;
-  default?: any;
-  description?: string;
-  sensitive?: boolean;
-  providers?: string[];
+const ACRONYMS: Record<string, string> = {
+  api: 'API',
+  html: 'HTML',
+  id: 'ID',
+  ip: 'IP',
+  json: 'JSON',
+  tls: 'TLS',
+  uid: 'UID',
+  upn: 'UPN',
+  url: 'URL',
 };
 
-type SchemaDef = { name: string; description: string; fields: FieldDef[] };
+const formatLabel = (name: string): string => (
+  name
+    .split('_')
+    .map((part) => ACRONYMS[part.toLowerCase()] || `${part.charAt(0).toUpperCase()}${part.slice(1)}`)
+    .join(' ')
+);
 
-const actionSchemas: Record<string, SchemaDef> = {
-  // ── Utility ──────────────────────────────────────────────────────────────
-  log: {
-    name: 'Log Message',
-    description: 'Log a message for debugging purposes',
-    fields: [
-      {
-        name: 'message', label: 'Message', type: 'textarea', required: true,
-        placeholder: 'Enter log message…',
-        description: 'Supports variables like {{trigger_data.field}}',
-      },
-      {
-        name: 'level', label: 'Log Level', type: 'select',
-        options: [
-          { value: 'info', label: 'Info' },
-          { value: 'warning', label: 'Warning' },
-          { value: 'error', label: 'Error' },
-        ],
-        default: 'info',
-      },
-    ],
-  },
-  delay: {
-    name: 'Delay',
-    description: 'Wait for a specified number of seconds',
-    fields: [
-      {
-        name: 'seconds', label: 'Seconds', type: 'number', required: true,
-        default: 5, description: 'Wait time (1–3600 seconds); node timeout must be greater',
-      },
-    ],
-  },
-
-  // ── Notification ─────────────────────────────────────────────────────────
-  send_email: {
-    name: 'Send Email',
-    description: 'Send an email notification',
-    fields: [
-      {
-        name: 'to', label: 'Recipients', type: 'array', required: true,
-        placeholder: 'email@example.com',
-        description: 'Add one or more email addresses',
-      },
-      {
-        name: 'subject', label: 'Subject', type: 'string', required: true,
-        placeholder: 'Alert: {{trigger_data.alert_name}}',
-      },
-      {
-        name: 'body', label: 'Email Body', type: 'textarea', required: true,
-        placeholder: 'Alert details:\nSeverity: {{trigger_data.severity}}\nSource IP: {{trigger_data.source_ip}}',
-      },
-      { name: 'is_html', label: 'HTML Email', type: 'boolean', default: false },
-    ],
-  },
-  send_webhook: {
-    name: 'Send Webhook',
-    description: 'Send an HTTP request to a webhook URL with a configurable JSON body',
-    fields: [
-      {
-        name: 'url', label: 'Webhook URL', type: 'string', required: true,
-        placeholder: 'https://api.example.com/webhook',
-      },
-      {
-        name: 'method', label: 'HTTP Method', type: 'select',
-        options: [
-          { value: 'GET', label: 'GET' },
-          { value: 'POST', label: 'POST' },
-          { value: 'PUT', label: 'PUT' },
-          { value: 'PATCH', label: 'PATCH' },
-        ],
-        default: 'POST',
-      },
-      {
-        name: 'headers', label: 'Headers', type: 'keyvalue',
-        description: 'Optional HTTP headers sent with the request',
-        sensitive: true,
-      },
-      {
-        name: 'body_template', label: 'Request Body (JSON)', type: 'textarea',
-        placeholder: '{\n  "alert": "{{trigger_data.alert_name}}",\n  "severity": "{{trigger_data.severity}}"\n}',
-        description: (
-          'JSON string.  Use {{variable.path}} for dynamic values.  ' +
-          'The system validates this is valid JSON before sending.'
-        ),
-      },
-      { name: 'timeout', label: 'Timeout (seconds)', type: 'number', default: 30 },
-    ],
-  },
-
-  // ── Enrichment ───────────────────────────────────────────────────────────
-  ip_lookup: {
-    name: 'IP Lookup',
-    description: 'Check IP reputation via a configurable threat-intel platform (e.g. AbuseIPDB, VirusTotal)',
-    fields: [
-      {
-        name: 'ip_address', label: 'IP Address', type: 'string', required: true,
-        placeholder: '{{trigger_data.source_ip}}',
-        description: 'Supports dynamic values extracted from the triggering case or alert',
-      },
-      {
-        name: 'api_url', label: 'Threat-Intel API URL', type: 'string', required: true,
-        placeholder: 'https://api.abuseipdb.com/api/v2/check',
-        description: 'Full API endpoint of the threat-intelligence platform',
-      },
-      {
-        name: 'api_key', label: 'API Key', type: 'password', required: true,
-        placeholder: 'Your API key',
-        description: 'API key / token for the threat-intelligence platform',
-      },
-      { name: 'timeout', label: 'Timeout (seconds)', type: 'number', default: 15 },
-    ],
-  },
-  hash_lookup: {
-    name: 'Hash Lookup',
-    description: 'Check file-hash reputation via a configurable threat-intel platform (e.g. VirusTotal)',
-    fields: [
-      {
-        name: 'hash_value', label: 'File Hash', type: 'string', required: true,
-        placeholder: '{{trigger_data.file_hash}}',
-        description: 'Supports dynamic values extracted from the triggering case or alert',
-      },
-      {
-        name: 'hash_type', label: 'Hash Type', type: 'select',
-        options: [
-          { value: 'md5', label: 'MD5' },
-          { value: 'sha1', label: 'SHA-1' },
-          { value: 'sha256', label: 'SHA-256' },
-        ],
-        default: 'sha256',
-      },
-      {
-        name: 'api_url', label: 'Threat-Intel API URL', type: 'string', required: true,
-        placeholder: 'https://www.virustotal.com/api/v3/files/{hash}',
-        description: 'Use {hash} as a placeholder – it will be replaced with the resolved hash value',
-      },
-      {
-        name: 'api_key', label: 'API Key', type: 'password', required: true,
-        placeholder: 'Your API key',
-      },
-      { name: 'timeout', label: 'Timeout (seconds)', type: 'number', default: 15 },
-    ],
-  },
-
-  // ── Containment ──────────────────────────────────────────────────────────
-  block_ip: {
-    name: 'Block IP',
-    description: 'Block an IP address via a security-device API (firewall / EDR)',
-    fields: [
-      {
-        name: 'provider', label: 'Provider', type: 'select', required: true,
-        options: [
-          { value: 'generic', label: 'Generic API' },
-          { value: 'opnsense', label: 'OPNsense' },
-        ],
-        default: 'generic',
-      },
-      {
-        name: 'ip_address', label: 'IP Address', type: 'string', required: true,
-        placeholder: '{{trigger_data.source_ip}}',
-        description: 'Supports dynamic values extracted from the triggering case or alert',
-      },
-      {
-        name: 'api_url', label: 'Security Device API URL', type: 'string', required: true,
-        placeholder: 'https://firewall.example.com/api/v1/block',
-      },
-      {
-        name: 'api_key', label: 'API Key', type: 'password', required: true,
-        placeholder: 'Your API key / token',
-        sensitive: true,
-      },
-      {
-        name: 'api_secret', label: 'API Secret', type: 'password', required: true,
-        placeholder: 'Your OPNsense API secret', sensitive: true, providers: ['opnsense'],
-      },
-      {
-        name: 'alias_name', label: 'Alias Name', type: 'string', required: true,
-        default: 'ARGUS_BLOCKLIST', providers: ['opnsense'],
-      },
-      {
-        name: 'verify_tls', label: 'Verify TLS Certificate', type: 'boolean',
-        default: true, providers: ['opnsense'],
-      },
-      {
-        name: 'kill_states', label: 'Kill Active States', type: 'boolean',
-        default: false, providers: ['opnsense'],
-      },
-      {
-        name: 'duration_hours', label: 'Block Duration (hours)', type: 'number',
-        default: 24, description: '0 = permanent block', providers: ['generic'],
-      },
-      {
-        name: 'reason', label: 'Reason', type: 'string',
-        placeholder: 'Blocked by SOAR workflow – {{trigger_data.alert_name}}',
-      },
-      { name: 'timeout', label: 'Timeout (seconds)', type: 'number', default: 15 },
-    ],
-  },
-  disable_user: {
-    name: 'Disable User',
-    description: 'Disable a user account via a security-device or AD API',
-    fields: [
-      {
-        name: 'username', label: 'Username / UPN', type: 'string', required: true,
-        placeholder: '{{trigger_data.username}}',
-        description: 'AD username or UPN – supports dynamic values from the triggering case or alert',
-      },
-      {
-        name: 'api_url', label: 'Security Device / AD API URL', type: 'string', required: true,
-        placeholder: 'https://ad.example.com/api/v1/users/disable',
-      },
-      {
-        name: 'api_key', label: 'API Key', type: 'password', required: true,
-        placeholder: 'Your API key / token',
-      },
-      {
-        name: 'reason', label: 'Reason', type: 'string',
-        placeholder: 'Disabled by SOAR workflow – {{trigger_data.alert_name}}',
-      },
-      { name: 'timeout', label: 'Timeout (seconds)', type: 'number', default: 15 },
-    ],
-  },
-
-  // ── Release ───────────────────────────────────────────────────────────────
-  release_ip: {
-    name: 'Release IP',
-    description: 'Release (unblock) an IP address via a security-device API',
-    fields: [
-      {
-        name: 'provider', label: 'Provider', type: 'select', required: true,
-        options: [
-          { value: 'generic', label: 'Generic API' },
-          { value: 'opnsense', label: 'OPNsense' },
-        ],
-        default: 'generic',
-      },
-      {
-        name: 'ip_address', label: 'IP Address', type: 'string', required: true,
-        placeholder: '{{trigger_data.source_ip}}',
-        description: 'Supports dynamic values extracted from the triggering case or alert',
-      },
-      {
-        name: 'api_url', label: 'Security Device API URL', type: 'string', required: true,
-        placeholder: 'https://firewall.example.com/api/v1/release',
-      },
-      {
-        name: 'api_key', label: 'API Key', type: 'password', required: true,
-        placeholder: 'Your API key / token',
-        sensitive: true,
-      },
-      {
-        name: 'api_secret', label: 'API Secret', type: 'password', required: true,
-        placeholder: 'Your OPNsense API secret', sensitive: true, providers: ['opnsense'],
-      },
-      {
-        name: 'alias_name', label: 'Alias Name', type: 'string', required: true,
-        default: 'ARGUS_BLOCKLIST', providers: ['opnsense'],
-      },
-      {
-        name: 'verify_tls', label: 'Verify TLS Certificate', type: 'boolean',
-        default: true, providers: ['opnsense'],
-      },
-      {
-        name: 'reason', label: 'Reason', type: 'string',
-        placeholder: 'Released by SOAR workflow',
-      },
-      { name: 'timeout', label: 'Timeout (seconds)', type: 'number', default: 15 },
-    ],
-  },
-  enable_user: {
-    name: 'Enable User',
-    description: 'Enable (re-activate) a user account via a security-device or AD API',
-    fields: [
-      {
-        name: 'username', label: 'Username / UPN', type: 'string', required: true,
-        placeholder: '{{trigger_data.username}}',
-        description: 'AD username or UPN – supports dynamic values from the triggering case or alert',
-      },
-      {
-        name: 'api_url', label: 'Security Device / AD API URL', type: 'string', required: true,
-        placeholder: 'https://ad.example.com/api/v1/users/enable',
-      },
-      {
-        name: 'api_key', label: 'API Key', type: 'password', required: true,
-        placeholder: 'Your API key / token',
-      },
-      {
-        name: 'reason', label: 'Reason', type: 'string',
-        placeholder: 'Enabled by SOAR workflow',
-      },
-      { name: 'timeout', label: 'Timeout (seconds)', type: 'number', default: 15 },
-    ],
-  },
-
-  // ── Integration ───────────────────────────────────────────────────────────
-  create_ticket: {
-    name: 'Create Ticket',
-    description: 'Create a new incident ticket in the SIEM',
-    fields: [
-      {
-        name: 'title', label: 'Ticket Title', type: 'string', required: true,
-        placeholder: 'Security Alert: {{trigger_data.alert_name}}',
-        description: 'Maps to EventTicket.title (max 255 chars)',
-      },
-      {
-        name: 'description', label: 'Description', type: 'textarea',
-        placeholder: 'Ticket description…',
-      },
-      {
-        name: 'status', label: 'Initial Status', type: 'select',
-        options: [
-          { value: 'new', label: 'New' },
-          { value: 'acknowledged', label: 'Acknowledged' },
-          { value: 'triaged', label: 'Triaged' },
-          { value: 'contained', label: 'Contained' },
-          { value: 'resolved', label: 'Resolved' },
-          { value: 'closed', label: 'Closed' },
-        ],
-        default: 'new',
-      },
-      {
-        name: 'priority', label: 'Priority', type: 'select',
-        options: [
-          { value: 'critical', label: 'Critical' },
-          { value: 'high', label: 'High' },
-          { value: 'medium', label: 'Medium' },
-          { value: 'low', label: 'Low' },
-        ],
-        default: 'medium',
-      },
-      {
-        name: 'event_category', label: 'Event Category', type: 'select',
-        options: [
-          { value: 'account_anomalies', label: 'Account Anomalies' },
-          { value: 'denial_of_service', label: 'Denial of Service' },
-          { value: 'malware', label: 'Malware' },
-          { value: 'system_anomalies', label: 'System Anomalies' },
-          { value: 'network_anomalies', label: 'Network Anomalies' },
-          { value: 'application_anomalies', label: 'Application Anomalies' },
-          { value: 'policy', label: 'Policy' },
-          { value: 'social_engineering', label: 'Social Engineering' },
-          { value: 'others', label: 'Others' },
-        ],
-        description: 'Incident category classification',
-      },
-      { name: 'current_assign_group', label: 'Assign Group', type: 'string', placeholder: 'SOC L1' },
-      { name: 'current_assign_owner', label: 'Assign Owner', type: 'string', placeholder: 'username' },
-      {
-        name: 'alert_message', label: 'Alert Message', type: 'textarea',
-        placeholder: '{{trigger_data.raw_message}}',
-        description: 'Raw alert message content',
-      },
-    ],
-  },
-  update_ticket: {
-    name: 'Update Ticket',
-    description: 'Update tickets selected by upstream context, then apply new field values',
-    fields: [
-      {
-        name: 'ticket_number', label: 'Ticket Number', type: 'string',
-        placeholder: '{{trigger_data.ticket_number}}',
-        description: 'Optional exact ticket number match',
-      },
-      {
-        name: 'title', label: 'Ticket Title', type: 'string',
-        placeholder: '{{trigger_data.title}}',
-        description: 'Optional exact ticket title match, e.g. {{trigger_data.title}}',
-      },
-      {
-        name: 'match_status', label: 'Match Current Status', type: 'select',
-        options: [
-          { value: 'new', label: 'New' },
-          { value: 'acknowledged', label: 'Acknowledged' },
-          { value: 'triaged', label: 'Triaged' },
-          { value: 'contained', label: 'Contained' },
-          { value: 'resolved', label: 'Resolved' },
-          { value: 'closed', label: 'Closed' },
-        ],
-      },
-      {
-        name: 'match_priority', label: 'Match Current Priority', type: 'select',
-        options: [
-          { value: 'critical', label: 'Critical' },
-          { value: 'high', label: 'High' },
-          { value: 'medium', label: 'Medium' },
-          { value: 'low', label: 'Low' },
-        ],
-      },
-      {
-        name: 'match_assign_group', label: 'Match Assign Group', type: 'string',
-        placeholder: 'SOC L1',
-      },
-      {
-        name: 'match_assign_owner', label: 'Match Assign Owner', type: 'string',
-        placeholder: 'username',
-      },
-      {
-        name: 'status', label: 'New Status', type: 'select',
-        options: [
-          { value: 'new', label: 'New' },
-          { value: 'acknowledged', label: 'Acknowledged' },
-          { value: 'triaged', label: 'Triaged' },
-          { value: 'contained', label: 'Contained' },
-          { value: 'resolved', label: 'Resolved' },
-          { value: 'closed', label: 'Closed' },
-        ],
-      },
-      {
-        name: 'priority', label: 'Priority', type: 'select',
-        options: [
-          { value: 'critical', label: 'Critical' },
-          { value: 'high', label: 'High' },
-          { value: 'medium', label: 'Medium' },
-          { value: 'low', label: 'Low' },
-        ],
-      },
-      {
-        name: 'current_assign_group', label: 'Assign Group', type: 'string',
-        placeholder: 'SOC L2',
-      },
-      {
-        name: 'current_assign_owner', label: 'Reassign To', type: 'string',
-        placeholder: 'new_owner',
-      },
-      {
-        name: 'event_result', label: 'Event Result', type: 'select',
-        options: [
-          { value: 'true_positive', label: 'True Positive' },
-          { value: 'false_positive', label: 'False Positive' },
-          { value: 'true_positive_benign', label: 'True Positive – Benign' },
-        ],
-        description: 'Classification result (used when resolving)',
-      },
-      {
-        name: 'event_category', label: 'Event Category', type: 'select',
-        options: [
-          { value: 'account_anomalies', label: 'Account Anomalies' },
-          { value: 'denial_of_service', label: 'Denial of Service' },
-          { value: 'malware', label: 'Malware' },
-          { value: 'system_anomalies', label: 'System Anomalies' },
-          { value: 'network_anomalies', label: 'Network Anomalies' },
-          { value: 'application_anomalies', label: 'Application Anomalies' },
-          { value: 'policy', label: 'Policy' },
-          { value: 'social_engineering', label: 'Social Engineering' },
-          { value: 'others', label: 'Others' },
-        ],
-      },
-      {
-        name: 'ticket_records', label: 'Handling Notes', type: 'textarea',
-        placeholder: 'Update notes…',
-        description: 'Detailed handling results and notes',
-      },
-      {
-        name: 'add_comment', label: 'Comment', type: 'textarea',
-        placeholder: 'Short comment…',
-        description: 'Compatibility field mapped to ticket records when provided',
-      },
-    ],
-  },
+const formatOptionLabel = (value: unknown): string => {
+  const raw = String(value);
+  if (raw && raw === raw.toUpperCase()) return raw;
+  return formatLabel(raw.replace(/-/g, '_'));
 };
 
-// ── Array input helper ────────────────────────────────────────────────────
+const isMultilineField = (name: string): boolean => (
+  /(^|_)(body|comment|description|message|notes?|records?|template)$/.test(name)
+);
+
+const resolveFieldType = (
+  name: string,
+  property: JsonSchemaProperty,
+  sensitive: boolean,
+): FieldDef['type'] => {
+  if (Array.isArray(property.enum)) return 'select';
+
+  const propertyType = Array.isArray(property.type)
+    ? property.type.find((item) => item !== 'null')
+    : property.type;
+
+  if (propertyType === 'object') return 'keyvalue';
+  if (propertyType === 'array') return 'array';
+  if (propertyType === 'boolean') return 'boolean';
+  if (propertyType === 'integer' || propertyType === 'number') return 'number';
+  if (sensitive) return 'password';
+  if (isMultilineField(name)) return 'textarea';
+  return 'string';
+};
+
+const fieldsFromSchema = (schema?: ActionConfigSchema): FieldDef[] => {
+  const required = new Set(schema?.required || []);
+  return Object.entries(schema?.properties || {}).map(([name, property]) => {
+    const sensitive = Boolean(property.writeOnly || property['x-sensitive']);
+    return {
+      name,
+      label: property.title || formatLabel(name),
+      type: resolveFieldType(name, property, sensitive),
+      required: required.has(name),
+      options: property.enum?.map((value) => ({
+        value: typeof value === 'number' ? value : String(value),
+        label: formatOptionLabel(value),
+      })),
+      default: property.default,
+      description: property.description,
+      sensitive,
+      minimum: property.minimum,
+      maximum: property.maximum,
+    };
+  });
+};
+
+// Provider-specific visibility is presentation behaviour that is not encoded
+// in the current backend JSON Schema. Field definitions still come entirely
+// from the registry response.
+const isFieldVisible = (actionType: string, fieldName: string, provider: string): boolean => {
+  if (actionType !== 'block_ip' && actionType !== 'release_ip') return true;
+
+  const normalizedProvider = String(provider || 'generic').toLowerCase();
+  if (normalizedProvider === 'opnsense') {
+    return fieldName !== 'duration_hours';
+  }
+
+  return !['api_secret', 'alias_name', 'verify_tls', 'kill_states'].includes(fieldName);
+};
+
 const ArrayInput: React.FC<{
   value?: string[];
   onChange?: (value: string[]) => void;
-  placeholder?: string;
-}> = ({ value = [], onChange, placeholder }) => {
+}> = ({ value = [], onChange }) => {
   const [inputValue, setInputValue] = useState('');
+  const items = Array.isArray(value) ? value : [];
 
   const handleAdd = () => {
-    if (inputValue.trim() && !value.includes(inputValue.trim())) {
-      onChange?.([...value, inputValue.trim()]);
+    const nextValue = inputValue.trim();
+    if (nextValue && !items.includes(nextValue)) {
+      onChange?.([...items, nextValue]);
       setInputValue('');
     }
   };
@@ -546,9 +179,8 @@ const ArrayInput: React.FC<{
     <div>
       <Space style={{ marginBottom: 8 }}>
         <Input
-          placeholder={placeholder}
           value={inputValue}
-          onChange={(e) => setInputValue(e.target.value)}
+          onChange={(event) => setInputValue(event.target.value)}
           onPressEnter={handleAdd}
           style={{ width: 220 }}
         />
@@ -557,11 +189,11 @@ const ArrayInput: React.FC<{
         </Button>
       </Space>
       <div>
-        {value.map((item, index) => (
+        {items.map((item, index) => (
           <Tag
-            key={index}
+            key={`${item}-${index}`}
             closable
-            onClose={() => onChange?.(value.filter((_, i) => i !== index))}
+            onClose={() => onChange?.(items.filter((_, itemIndex) => itemIndex !== index))}
             style={{ marginBottom: 4 }}
           >
             {item}
@@ -578,7 +210,6 @@ const KeyValueInput: React.FC<{
 }> = ({ value = {}, onChange }) => {
   const [keyInput, setKeyInput] = useState('');
   const [valueInput, setValueInput] = useState('');
-
   const entries = Object.entries(value || {});
 
   const handleAdd = () => {
@@ -599,15 +230,15 @@ const KeyValueInput: React.FC<{
     <div>
       <Space style={{ marginBottom: 8, width: '100%' }} wrap>
         <Input
-          placeholder="Header name"
+          placeholder="Key"
           value={keyInput}
-          onChange={(e) => setKeyInput(e.target.value)}
+          onChange={(event) => setKeyInput(event.target.value)}
           style={{ width: 180 }}
         />
         <Input
-          placeholder="Header value"
+          placeholder="Value"
           value={valueInput}
-          onChange={(e) => setValueInput(e.target.value)}
+          onChange={(event) => setValueInput(event.target.value)}
           style={{ width: 220 }}
         />
         <Button type="primary" size="small" icon={<PlusOutlined />} onClick={handleAdd}>
@@ -630,9 +261,9 @@ const KeyValueInput: React.FC<{
   );
 };
 
-// ── Main component ────────────────────────────────────────────────────────
 const ActionConfigBuilder: React.FC<ActionConfigBuilderProps> = ({
   actionType,
+  actionInfo,
   config,
   configKey,
   configuredSecretFields = [],
@@ -648,13 +279,12 @@ const ActionConfigBuilder: React.FC<ActionConfigBuilderProps> = ({
   const initialTargets = useRef<Record<string, any>>({});
   const provider = Form.useWatch('provider', form) || config?.provider || 'generic';
 
-  const schema = actionSchemas[actionType];
+  const schema = actionInfo?.config_schema as ActionConfigSchema | undefined;
+  const fields = fieldsFromSchema(schema);
   const configuredSecretSet = new Set(configuredSecretFields);
-  const targetCredentialFields = actionType === 'send_webhook'
-    ? ['headers']
-    : actionType === 'block_ip' || actionType === 'release_ip'
-      ? ['api_key', 'api_secret']
-      : ['api_key'];
+  const targetCredentialFields = fields
+    .filter((field) => field.sensitive)
+    .map((field) => field.name);
   const isConfiguredForCurrentTarget = (fieldName: string) => (
     configuredSecretSet.has(fieldName)
     && !(protectedTargetChanged && targetCredentialFields.includes(fieldName))
@@ -674,17 +304,16 @@ const ActionConfigBuilder: React.FC<ActionConfigBuilderProps> = ({
     };
     setProtectedTargetChanged(false);
     setAliasChanged(false);
-    if (config) {
-      const safeConfig = Object.fromEntries(
-        Object.entries(config).filter(([name, value]) => (
-          !configuredSecretFields.includes(name)
-          && !(typeof value === 'string' && value.startsWith('enc:v1:'))
-        ))
-      );
-      form.resetFields();
-      form.setFieldsValue(safeConfig);
-      setJsonValue(JSON.stringify(safeConfig, null, 2));
-    }
+
+    const safeConfig = Object.fromEntries(
+      Object.entries(config || {}).filter(([name, value]) => (
+        !configuredSecretFields.includes(name)
+        && !(typeof value === 'string' && value.startsWith('enc:v1:'))
+      )),
+    );
+    form.resetFields();
+    form.setFieldsValue(safeConfig);
+    setJsonValue(JSON.stringify(safeConfig, null, 2));
   }, [actionType, config, configKey, configuredSecretFields, form]);
 
   const applyTargetProtection = (inputValues: Record<string, any>) => {
@@ -710,16 +339,9 @@ const ActionConfigBuilder: React.FC<ActionConfigBuilderProps> = ({
     setAliasChanged(nextAliasChanged);
 
     if (actionType === 'send_webhook' && protectedChanged && !values.headers) {
-      // Headers are optional. A URL change clears them explicitly unless the
-      // user supplies a replacement, so they can never leak to a new target.
       values.headers = null;
     }
-    if (
-      isOPNsenseAction
-      && values.provider === 'generic'
-    ) {
-      // OPNsense's optional secret must be explicitly cleared when switching
-      // providers; the API key remains required and must be entered again.
+    if (isOPNsenseAction && values.provider === 'generic') {
       values.api_secret = null;
     }
     return values;
@@ -752,8 +374,6 @@ const ActionConfigBuilder: React.FC<ActionConfigBuilderProps> = ({
 
   const renderField = (field: FieldDef) => {
     switch (field.type) {
-      case 'string':
-        return <Input placeholder={field.placeholder} />;
       case 'password':
         return (
           <Input.Password
@@ -761,34 +381,39 @@ const ActionConfigBuilder: React.FC<ActionConfigBuilderProps> = ({
             placeholder={
               isConfiguredForCurrentTarget(field.name)
                 ? 'Configured — leave blank to keep it'
-                : field.placeholder
+                : `Enter ${field.label}`
             }
           />
         );
       case 'number':
-        return <InputNumber style={{ width: '100%' }} min={0} />;
+        return (
+          <InputNumber
+            style={{ width: '100%' }}
+            min={field.minimum}
+            max={field.maximum}
+          />
+        );
       case 'boolean':
         return <Switch />;
       case 'select':
         return <Select options={field.options} placeholder="Select…" allowClear />;
       case 'textarea':
-        return <TextArea rows={4} placeholder={field.placeholder} style={{ fontFamily: 'monospace', fontSize: 12 }} />;
+        return <TextArea rows={4} style={{ fontFamily: 'monospace', fontSize: 12 }} />;
       case 'array':
-        return <ArrayInput placeholder={field.placeholder} />;
+        return <ArrayInput />;
       case 'keyvalue':
         return <KeyValueInput />;
       default:
-        return <Input placeholder={field.placeholder} />;
+        return <Input />;
     }
   };
 
-  // If no schema is defined, fall back to raw JSON
-  if (!schema) {
+  if (!schema?.properties) {
     return (
       <div>
         <Alert
           message="Custom Action"
-          description="No visual editor available for this action type. Configure using JSON below."
+          description="No configuration schema is available for this action type. Configure it as JSON below."
           type="info"
           showIcon
           style={{ marginBottom: 16 }}
@@ -797,7 +422,7 @@ const ActionConfigBuilder: React.FC<ActionConfigBuilderProps> = ({
           rows={10}
           style={{ fontFamily: 'monospace' }}
           value={jsonValue}
-          onChange={(e) => handleJsonChange(e.target.value)}
+          onChange={(event) => handleJsonChange(event.target.value)}
         />
         {jsonError && <Text type="danger">{jsonError}</Text>}
       </div>
@@ -824,9 +449,9 @@ const ActionConfigBuilder: React.FC<ActionConfigBuilderProps> = ({
           initialValues={config}
         >
           <Card size="small" style={{ marginBottom: 16, background: '#f5f5f5' }}>
-            <Text strong>{schema.name}</Text>
+            <Text strong>{actionInfo?.name || formatLabel(actionType)}</Text>
             <br />
-            <Text type="secondary" style={{ fontSize: 12 }}>{schema.description}</Text>
+            <Text type="secondary" style={{ fontSize: 12 }}>{actionInfo?.description}</Text>
           </Card>
 
           {protectedTargetChanged && (
@@ -853,42 +478,49 @@ const ActionConfigBuilder: React.FC<ActionConfigBuilderProps> = ({
             />
           )}
 
-          {schema.fields
-            .filter((field) => !field.providers || field.providers.includes(provider))
-            .map((field) => (
-            <Form.Item
-              key={field.name}
-              name={field.name}
-              label={
-                <Space>
-                  {field.label}
-                  {field.required && <Text type="danger">*</Text>}
-                  {isConfiguredForCurrentTarget(field.name) && (
-                    <Tag color="green">Configured</Tag>
-                  )}
-                  {field.description && (
-                    <Tooltip title={field.description}>
-                      <InfoCircleOutlined style={{ color: '#999' }} />
-                    </Tooltip>
-                  )}
-                </Space>
-              }
-              rules={
-                field.required && !isConfiguredForCurrentTarget(field.name)
-                  ? [{ required: true, message: `${field.label} is required` }]
-                  : []
-              }
-              valuePropName={field.type === 'boolean' ? 'checked' : 'value'}
-              initialValue={field.default}
-              help={
-                isConfiguredForCurrentTarget(field.name)
-                  ? 'Already configured. Leave empty to keep the existing value.'
-                  : undefined
-              }
-            >
-              {renderField(field)}
-            </Form.Item>
-          ))}
+          {fields
+            .filter((field) => isFieldVisible(actionType, field.name, provider))
+            .map((field) => {
+              const required = field.required || (
+                (actionType === 'block_ip' || actionType === 'release_ip')
+                && String(provider).toLowerCase() === 'opnsense'
+                && field.name === 'api_secret'
+              );
+              return (
+                <Form.Item
+                  key={field.name}
+                  name={field.name}
+                  label={
+                    <Space>
+                      {field.label}
+                      {required && <Text type="danger">*</Text>}
+                      {isConfiguredForCurrentTarget(field.name) && (
+                        <Tag color="green">Configured</Tag>
+                      )}
+                      {field.description && (
+                        <Tooltip title={field.description}>
+                          <InfoCircleOutlined style={{ color: '#999' }} />
+                        </Tooltip>
+                      )}
+                    </Space>
+                  }
+                  rules={
+                    required && !isConfiguredForCurrentTarget(field.name)
+                      ? [{ required: true, message: `${field.label} is required` }]
+                      : []
+                  }
+                  valuePropName={field.type === 'boolean' ? 'checked' : 'value'}
+                  initialValue={field.default}
+                  help={
+                    isConfiguredForCurrentTarget(field.name)
+                      ? 'Already configured. Leave empty to keep the existing value.'
+                      : undefined
+                  }
+                >
+                  {renderField(field)}
+                </Form.Item>
+              );
+            })}
 
           <Divider />
           <Alert
@@ -922,7 +554,7 @@ const ActionConfigBuilder: React.FC<ActionConfigBuilderProps> = ({
             rows={15}
             style={{ fontFamily: 'monospace' }}
             value={jsonValue}
-            onChange={(e) => handleJsonChange(e.target.value)}
+            onChange={(event) => handleJsonChange(event.target.value)}
           />
           {jsonError && (
             <Text type="danger" style={{ display: 'block', marginTop: 8 }}>
@@ -936,4 +568,3 @@ const ActionConfigBuilder: React.FC<ActionConfigBuilderProps> = ({
 };
 
 export default ActionConfigBuilder;
-

--- a/frontend/src/modules/workflows/components/VisualWorkflowEditor.tsx
+++ b/frontend/src/modules/workflows/components/VisualWorkflowEditor.tsx
@@ -45,6 +45,7 @@ import {
   List,
   Popconfirm,
   Empty,
+  Tooltip,
 } from 'antd';
 import {
   SaveOutlined,
@@ -187,7 +188,14 @@ const getApiErrorMessage = (err: any, fallback: string): string => {
   if (typeof data === 'string') return data;
   if (typeof data?.detail === 'string') return data.detail;
   if (typeof data?.error === 'string') return data.error;
-  return fallback;
+  const messages: string[] = [];
+  const collect = (value: any) => {
+    if (typeof value === 'string') messages.push(value);
+    else if (Array.isArray(value)) value.forEach(collect);
+    else if (value && typeof value === 'object') Object.values(value).forEach(collect);
+  };
+  collect(data);
+  return messages[0] || fallback;
 };
 
 const normalizeBindingLabelFilters = (value: any): Array<{ label_name: string; label_value: string }> => {
@@ -243,6 +251,7 @@ const stepsToNodes = (steps: WorkflowStep[]): Node[] => {
       actionType: step.action_type,
       category: step.node_category || 'utility',
       config: step.action_config,
+      configuredSecretFields: step.configured_secret_fields || [],
       condition: step.condition,
       isActive: step.is_active,
     },
@@ -815,6 +824,7 @@ const VisualWorkflowEditor: React.FC<VisualWorkflowEditorProps> = ({
             category: template.node_category,
             actionType: template.action_type,
             config: template.action_config || {},
+            configuredSecretFields: template.configured_secret_fields || [],
             condition: template.condition || {},
             timeout: template.timeout_seconds,
             onFailure: template.on_failure,
@@ -1315,10 +1325,28 @@ const VisualWorkflowEditor: React.FC<VisualWorkflowEditorProps> = ({
           </Col>
           <Col>
             <Space>
-              {!isNew && workflow?.is_active && (
-                <Button icon={<PlayCircleOutlined />} onClick={handleExecute}>
-                  Execute
-                </Button>
+              {!isNew && (
+                <Tooltip
+                  title={
+                    !workflow?.is_active
+                      ? 'Activate this workflow before execution'
+                      : !workflow?.published_version
+                        ? 'Publish this workflow before execution'
+                        : workflow.has_unpublished_changes
+                          ? `Execute the last published version (v${workflow.published_version})`
+                          : `Execute published version v${workflow.published_version}`
+                  }
+                >
+                  <span>
+                    <Button
+                      icon={<PlayCircleOutlined />}
+                      onClick={handleExecute}
+                      disabled={!workflow?.is_active || !workflow?.published_version}
+                    >
+                      Execute
+                    </Button>
+                  </span>
+                </Tooltip>
               )}
               <Button icon={<SaveOutlined />} onClick={() => handleSave(false)} loading={saving}>
                 Save Draft
@@ -1763,6 +1791,8 @@ const VisualWorkflowEditor: React.FC<VisualWorkflowEditorProps> = ({
                 <ActionConfigBuilder
                   actionType={selectedNode.data.actionType || ''}
                   config={actionConfig}
+                  configKey={String(selectedNode.id)}
+                  configuredSecretFields={selectedNode.data.configuredSecretFields || []}
                   onChange={(newConfig) => {
                     setActionConfig(newConfig);
                   }}
@@ -1771,7 +1801,7 @@ const VisualWorkflowEditor: React.FC<VisualWorkflowEditorProps> = ({
                 <Row gutter={16}>
                   <Col span={12}>
                     <Form.Item name="timeout_seconds" label="Timeout (s)">
-                      <InputNumber min={1} max={3600} style={{ width: '100%' }} />
+                      <InputNumber min={1} max={3601} style={{ width: '100%' }} />
                     </Form.Item>
                   </Col>
                   <Col span={12}>
@@ -1971,7 +2001,7 @@ const VisualWorkflowEditor: React.FC<VisualWorkflowEditorProps> = ({
           <Row gutter={12}>
             <Col span={8}>
               <Form.Item name="timeout_seconds" label="Timeout (s)">
-                <InputNumber min={1} max={3600} style={{ width: '100%' }} />
+                <InputNumber min={1} max={3601} style={{ width: '100%' }} />
               </Form.Item>
             </Col>
             <Col span={8}>

--- a/frontend/src/modules/workflows/components/VisualWorkflowEditor.tsx
+++ b/frontend/src/modules/workflows/components/VisualWorkflowEditor.tsx
@@ -1790,6 +1790,9 @@ const VisualWorkflowEditor: React.FC<VisualWorkflowEditorProps> = ({
                 <Divider>Action Configuration</Divider>
                 <ActionConfigBuilder
                   actionType={selectedNode.data.actionType || ''}
+                  actionInfo={availableActions.find(
+                    (action) => action.action_type === selectedNode.data.actionType
+                  )}
                   config={actionConfig}
                   configKey={String(selectedNode.id)}
                   configuredSecretFields={selectedNode.data.configuredSecretFields || []}

--- a/frontend/src/services/workflows/index.ts
+++ b/frontend/src/services/workflows/index.ts
@@ -35,7 +35,10 @@ export {
   deleteSavedWorkflowNode,
   // Publish & Import
   publishWorkflow,
-  listPublishedManifests,
-  importWorkflowFromManifest,
+  exportWorkflow,
+  // Server-manifest recovery is intentionally disabled (not deleted) because
+  // disaster recovery is out of scope and manifest/DB UUIDs may not match.
+  // listPublishedManifests,
+  // importWorkflowFromManifest,
   importWorkflowFromFile,
 } from '../../api';


### PR DESCRIPTION
## Summary

This PR strengthens the workflow module with encrypted secret handling, published-workflow lifecycle enforcement, Prefect execution persistence, OPNsense containment actions, and corresponding frontend support.

## What changed

### Secure workflow configuration

- Encrypt sensitive action configuration at rest using a Fernet key ring.
- Decrypt credentials only immediately before action execution.
- Redact sensitive values from API responses, logs, results, tracebacks, and execution history.
- Preserve existing write-only credentials during workflow edits.
- Add a management command for migrating plaintext secrets and rotating encryption keys.
- Add `WORKFLOW_ENCRYPTION_KEYS` configuration and declare `cryptography` as a direct dependency because the workflow code imports it directly, even though Prefect already provides it as a transitive dependency.

### Workflow publishing and lifecycle

- Require workflows to be active and published before execution.
- Allow workflows with unpublished draft changes to execute their last published version.
- Export the last published workflow snapshot while keeping secrets encrypted.
- Import transferred workflows as inactive drafts for review.
- Remove encrypted credentials during import when they cannot be validated in the target environment.
- Disable the unsafe server-local manifest recovery route.

### Prefect integration

- Persist workflow and step execution states while Prefect runs.
- Propagate business failures to Prefect as failed flow runs.
- Merge action-template defaults into serialized step configuration without exposing plaintext credentials.
- Align deployment filtering and schedule updates with Prefect 3 API behavior.

### OPNsense containment

- Add OPNsense-compatible IP block and release actions.
- Validate IP addresses, alias names, HTTPS endpoints, authentication, and business-level API responses.
- Support optional TLS verification control and state cleanup.
- Preserve compatibility with the existing generic containment API.

### Frontend

- Add write-only secret fields and configured-secret indicators.
- Require credentials to be re-entered when the target system changes.
- Add published workflow export and JSON import feedback.
- Display published-version status and disable execution until a workflow is active and published.

## Configuration

Production environments must configure a Fernet key:

```env
WORKFLOW_ENCRYPTION_KEYS=<primary-fernet-key>[,<fallback-key>...]
```
The first key encrypts new values. Remaining keys may decrypt values encrypted with older keys.
Existing deployments can use the included `migrate_workflow_secrets` management command to inspect, migrate, and rotate stored workflow credentials.

## Important behavior changes
Production startup requires WORKFLOW_ENCRYPTION_KEYS when DEBUG=False.
Unpublished or inactive workflows can no longer be executed.
Imported workflows are inactive drafts and may require credentials to be entered again.